### PR TITLE
Add fake crds to allow for testing in kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ CONTAINER_TOOL ?= podman
 
 # KIND defines the path to your kind binary.
 KIND = kind
+KIND_CLUSTER_NAME = innabox
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -164,7 +165,7 @@ image-run: ## Run container image locally.
 
 .PHONY: kind-load
 kind-load: image-build
-	$(KIND) load docker-image ${IMG}
+	$(KIND) load docker-image -n ${KIND_CLUSTER_NAME} ${IMG}
 
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:

--- a/config/crd/fakes/hypershift.openshift.io_hostedclusters.yaml
+++ b/config/crd/fakes/hypershift.openshift.io_hostedclusters.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostedclusters.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: HostedCluster
+    listKind: HostedClusterList
+    plural: hostedclusters
+    shortNames:
+    - hc
+    singular: hostedcluster
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HostedCluster schema
+        type: object
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostedClusterSpec defines the desired state of HostedCluster
+            type: object
+            properties:
+              clusterID:
+                type: string
+          status:
+            description: HostedClusterStatus defines the observed state of HostedCluster
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/fakes/hypershift.openshift.io_nodepools.yaml
+++ b/config/crd/fakes/hypershift.openshift.io_nodepools.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodepools.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    shortNames:
+    - np
+    - nps
+    singular: nodepool
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: NodePool schema
+        type: object
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodePoolSpec defines the desired state of NodePool
+            type: object
+            properties:
+              clusterName:
+                type: string
+          status:
+            description: NodePoolStatus defines the observed state of NodePool
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/fakes/kustomization.yaml
+++ b/config/crd/fakes/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- hypershift.openshift.io_hostedclusters.yaml
+- hypershift.openshift.io_nodepools.yaml


### PR DESCRIPTION
This adds fake crds for hostedclusters and nodepools; this allows the operator to run successfully in kind. To install these into a cluster:

    kubectl apply -k config/crd/fakes