### PR TITLE
Remove unused templates client from feedback controller

### DIFF
--- a/internal/controller/feedback_controller.go
+++ b/internal/controller/feedback_controller.go
@@ -34,10 +34,9 @@ import (
 
 // FeedbackReconciler sends updates to the fulfillment service.
 type FeedbackReconciler struct {
-	logger          logr.Logger
-	hubClient       clnt.Client
-	clustersClient  privatev1.ClustersClient
-	templatesClient privatev1.ClusterTemplatesClient
+	logger         logr.Logger
+	hubClient      clnt.Client
+	clustersClient privatev1.ClustersClient
 }
 
 // feedbackReconcilerTask contains data that is used for the reconciliation of a specific cluster order, so there is less
@@ -52,10 +51,9 @@ type feedbackReconcilerTask struct {
 // NewFeedbackReconciler creates a reconciler that sends to the fulfillment service updates about cluster orders.
 func NewFeedbackReconciler(logger logr.Logger, hubClient clnt.Client, grpcConn *grpc.ClientConn) *FeedbackReconciler {
 	return &FeedbackReconciler{
-		logger:          logger,
-		hubClient:       hubClient,
-		clustersClient:  privatev1.NewClustersClient(grpcConn),
-		templatesClient: privatev1.NewClusterTemplatesClient(grpcConn),
+		logger:         logger,
+		hubClient:      hubClient,
+		clustersClient: privatev1.NewClustersClient(grpcConn),
 	}
 }
 


### PR DESCRIPTION
After the changes to merge the `ClusterOrder` and `Cluster` objects the feedback controller no longer needs to fetch the templates, but the templates client is still there, unused. This patch removes it.