### PR TITLE
MGMT-23197: Add SecurityGroup feedback controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -524,7 +524,17 @@ func setupNetworkingControllers(
 		return fmt.Errorf("subnet controller: %w", err)
 	}
 
-	// Setup SecurityGroup controller (no feedback controller yet)
+	// Setup SecurityGroup controller and feedback
+	if grpcConn != nil {
+		if err := controller.NewSecurityGroupFeedbackReconciler(
+			localMgr.GetClient(),
+			grpcConn,
+			networkingNamespace,
+		).SetupWithManager(localMgr); err != nil {
+			return fmt.Errorf("securitygroup feedback controller: %w", err)
+		}
+	}
+
 	if err := (&controller.SecurityGroupReconciler{
 		Client:               localMgr.GetClient(),
 		Scheme:               localMgr.GetScheme(),

--- a/internal/controller/securitygroup_feedback_controller.go
+++ b/internal/controller/securitygroup_feedback_controller.go
@@ -1,0 +1,191 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/osac-project/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac-operator/internal/api/osac/private/v1"
+)
+
+// SecurityGroupFeedbackReconciler sends updates to the fulfillment service.
+type SecurityGroupFeedbackReconciler struct {
+	hubClient            clnt.Client
+	securityGroupsClient privatev1.SecurityGroupsClient
+	networkingNamespace  string
+}
+
+// securityGroupFeedbackReconcilerTask contains data that is used for the reconciliation of a specific security group, so there is less
+// need to pass around as function parameters that and other related objects.
+type securityGroupFeedbackReconcilerTask struct {
+	r             *SecurityGroupFeedbackReconciler
+	object        *v1alpha1.SecurityGroup
+	securityGroup *privatev1.SecurityGroup
+}
+
+// NewSecurityGroupFeedbackReconciler creates a reconciler that sends to the fulfillment service updates about security groups.
+func NewSecurityGroupFeedbackReconciler(hubClient clnt.Client, grpcConn *grpc.ClientConn, networkingNamespace string) *SecurityGroupFeedbackReconciler {
+	return &SecurityGroupFeedbackReconciler{
+		hubClient:            hubClient,
+		securityGroupsClient: privatev1.NewSecurityGroupsClient(grpcConn),
+		networkingNamespace:  networkingNamespace,
+	}
+}
+
+// SetupWithManager adds the reconciler to the controller manager.
+func (r *SecurityGroupFeedbackReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("securitygroup-feedback").
+		For(&v1alpha1.SecurityGroup{}, builder.WithPredicates(NetworkingNamespacePredicate(r.networkingNamespace))).
+		Complete(r)
+}
+
+// Reconcile is the implementation of the reconciler interface.
+func (r *SecurityGroupFeedbackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (result ctrl.Result, err error) {
+	log := ctrllog.FromContext(ctx)
+
+	// Fetch the object to reconcile, and do nothing if it no longer exists:
+	object := &v1alpha1.SecurityGroup{}
+	err = r.hubClient.Get(ctx, request.NamespacedName, object)
+	if err != nil {
+		err = clnt.IgnoreNotFound(err)
+		return //nolint:nakedret
+	}
+
+	// Get the identifier of the security group from the labels. If this isn't present it means that the object wasn't
+	// created by the fulfillment service, so we ignore it.
+	securityGroupID, ok := object.Labels[osacSecurityGroupIDLabel]
+	if !ok {
+		log.Info(
+			"There is no label containing the security group identifier, will ignore it",
+			"label", osacSecurityGroupIDLabel,
+		)
+		return
+	}
+
+	// Check if the SecurityGroup is being deleted before fetching from fulfillment service
+	if !object.ObjectMeta.DeletionTimestamp.IsZero() {
+		log.Info(
+			"SecurityGroup is being deleted, skipping feedback reconciliation",
+		)
+		return
+	}
+
+	// Fetch the security group:
+	securityGroup, err := r.fetchSecurityGroup(ctx, securityGroupID)
+	if err != nil {
+		return
+	}
+
+	// Create a task to do the rest of the job, but using copies of the objects, so that we can later compare the
+	// before and after values and save only the objects that have changed.
+	t := &securityGroupFeedbackReconcilerTask{
+		r:             r,
+		object:        object,
+		securityGroup: clone(securityGroup),
+	}
+
+	t.handleUpdate(ctx)
+
+	// Save the objects that have changed:
+	err = r.saveSecurityGroup(ctx, securityGroup, t.securityGroup)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (r *SecurityGroupFeedbackReconciler) fetchSecurityGroup(ctx context.Context, id string) (securityGroup *privatev1.SecurityGroup, err error) {
+	response, err := r.securityGroupsClient.Get(ctx, privatev1.SecurityGroupsGetRequest_builder{
+		Id: id,
+	}.Build())
+	if err != nil {
+		return
+	}
+	securityGroup = response.GetObject()
+	if !securityGroup.HasSpec() {
+		securityGroup.SetSpec(&privatev1.SecurityGroupSpec{})
+	}
+	if !securityGroup.HasStatus() {
+		securityGroup.SetStatus(&privatev1.SecurityGroupStatus{})
+	}
+	return
+}
+
+func (r *SecurityGroupFeedbackReconciler) saveSecurityGroup(ctx context.Context, before, after *privatev1.SecurityGroup) error {
+	log := ctrllog.FromContext(ctx)
+
+	if !equal(after, before) {
+		log.Info(
+			"Updating security group",
+			"before", before,
+			"after", after,
+		)
+		_, err := r.securityGroupsClient.Update(ctx, privatev1.SecurityGroupsUpdateRequest_builder{
+			Object: after,
+		}.Build())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *securityGroupFeedbackReconcilerTask) handleUpdate(ctx context.Context) {
+	t.syncPhase(ctx)
+}
+
+func (t *securityGroupFeedbackReconcilerTask) syncPhase(ctx context.Context) {
+	switch t.object.Status.Phase {
+	case v1alpha1.SecurityGroupPhaseProgressing:
+		t.syncPhaseProgressing()
+	case v1alpha1.SecurityGroupPhaseFailed:
+		t.syncPhaseFailed()
+	case v1alpha1.SecurityGroupPhaseReady:
+		t.syncPhaseReady()
+	case v1alpha1.SecurityGroupPhaseDeleting:
+		t.syncPhaseDeleting()
+	default:
+		log := ctrllog.FromContext(ctx)
+		log.Info(
+			"Unknown phase, will ignore it",
+			"phase", t.object.Status.Phase,
+		)
+	}
+}
+
+func (t *securityGroupFeedbackReconcilerTask) syncPhaseProgressing() {
+	t.securityGroup.GetStatus().SetState(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING)
+}
+
+func (t *securityGroupFeedbackReconcilerTask) syncPhaseFailed() {
+	t.securityGroup.GetStatus().SetState(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_FAILED)
+}
+
+func (t *securityGroupFeedbackReconcilerTask) syncPhaseReady() {
+	securityGroupStatus := t.securityGroup.GetStatus()
+	securityGroupStatus.SetState(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY)
+}
+
+func (t *securityGroupFeedbackReconcilerTask) syncPhaseDeleting() {
+	// Deleting state maps to PENDING as deletion is in progress
+	t.securityGroup.GetStatus().SetState(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING)
+}

--- a/internal/controller/securitygroup_feedback_controller_test.go
+++ b/internal/controller/securitygroup_feedback_controller_test.go
@@ -1,0 +1,441 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/osac-project/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac-operator/internal/api/osac/private/v1"
+)
+
+var _ = Describe("SecurityGroupFeedbackController", func() {
+	const (
+		sgName      = "test-sg"
+		sgNamespace = "test-namespace"
+		sgID        = "sg-123"
+		testVnetRef = "vnet-abc"
+	)
+
+	var (
+		ctx        context.Context
+		k8sClient  client.Client
+		mockServer *mockSecurityGroupsServer
+		reconciler *SecurityGroupFeedbackReconciler
+		grpcServer *grpc.Server
+		listener   *bufconn.Listener
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		// Create fake Kubernetes client
+		scheme := runtime.NewScheme()
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+		k8sClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		// Create mock gRPC server
+		mockServer = &mockSecurityGroupsServer{
+			securityGroups: make(map[string]*privatev1.SecurityGroup),
+			updates:        make([]*privatev1.SecurityGroup, 0),
+		}
+		listener = bufconn.Listen(1024 * 1024)
+		grpcServer = grpc.NewServer()
+		privatev1.RegisterSecurityGroupsServer(grpcServer, mockServer)
+
+		go func() {
+			_ = grpcServer.Serve(listener)
+		}()
+
+		// Create gRPC client connection
+		conn, err := grpc.NewClient("passthrough:///bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return listener.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create reconciler
+		reconciler = NewSecurityGroupFeedbackReconciler(k8sClient, conn, sgNamespace)
+	})
+
+	AfterEach(func() {
+		if grpcServer != nil {
+			grpcServer.Stop()
+		}
+		if listener != nil {
+			_ = listener.Close()
+		}
+	})
+
+	Context("when reconciling a SecurityGroup CR", func() {
+		It("should sync Phase=Ready to database state=READY", func() {
+			// Create security group in mock database
+			sg := &privatev1.SecurityGroup{
+				Id: sgID,
+				Metadata: &privatev1.Metadata{
+					Name: sgName,
+				},
+				Spec: &privatev1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: &privatev1.SecurityGroupStatus{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING,
+				},
+			}
+			mockServer.addSecurityGroup(sg)
+
+			// Create SecurityGroup CR with Phase=Ready
+			cr := &v1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sgName,
+					Namespace: sgNamespace,
+					Labels: map[string]string{
+						osacSecurityGroupIDLabel: sgID,
+					},
+				},
+				Spec: v1alpha1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: v1alpha1.SecurityGroupStatus{
+					Phase: v1alpha1.SecurityGroupPhaseReady,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			// Reconcile
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sgName,
+					Namespace: sgNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Assert gRPC Update called with state=READY
+			Expect(mockServer.updates).To(HaveLen(1))
+			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY))
+		})
+
+		It("should sync Phase=Progressing to database state=PENDING", func() {
+			sg := &privatev1.SecurityGroup{
+				Id: sgID,
+				Metadata: &privatev1.Metadata{
+					Name: sgName,
+				},
+				Spec: &privatev1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: &privatev1.SecurityGroupStatus{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				},
+			}
+			mockServer.addSecurityGroup(sg)
+
+			cr := &v1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sgName,
+					Namespace: sgNamespace,
+					Labels: map[string]string{
+						osacSecurityGroupIDLabel: sgID,
+					},
+				},
+				Spec: v1alpha1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: v1alpha1.SecurityGroupStatus{
+					Phase: v1alpha1.SecurityGroupPhaseProgressing,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sgName,
+					Namespace: sgNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockServer.updates).To(HaveLen(1))
+			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING))
+		})
+
+		It("should sync Phase=Failed to database state=FAILED", func() {
+			sg := &privatev1.SecurityGroup{
+				Id: sgID,
+				Metadata: &privatev1.Metadata{
+					Name: sgName,
+				},
+				Spec: &privatev1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: &privatev1.SecurityGroupStatus{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING,
+				},
+			}
+			mockServer.addSecurityGroup(sg)
+
+			cr := &v1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sgName,
+					Namespace: sgNamespace,
+					Labels: map[string]string{
+						osacSecurityGroupIDLabel: sgID,
+					},
+				},
+				Spec: v1alpha1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: v1alpha1.SecurityGroupStatus{
+					Phase: v1alpha1.SecurityGroupPhaseFailed,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sgName,
+					Namespace: sgNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockServer.updates).To(HaveLen(1))
+			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_FAILED))
+		})
+
+		It("should sync Phase=Deleting to database state=PENDING", func() {
+			sg := &privatev1.SecurityGroup{
+				Id: sgID,
+				Metadata: &privatev1.Metadata{
+					Name: sgName,
+				},
+				Spec: &privatev1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: &privatev1.SecurityGroupStatus{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				},
+			}
+			mockServer.addSecurityGroup(sg)
+
+			cr := &v1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sgName,
+					Namespace: sgNamespace,
+					Labels: map[string]string{
+						osacSecurityGroupIDLabel: sgID,
+					},
+				},
+				Spec: v1alpha1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: v1alpha1.SecurityGroupStatus{
+					Phase: v1alpha1.SecurityGroupPhaseDeleting,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sgName,
+					Namespace: sgNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockServer.updates).To(HaveLen(1))
+			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING))
+		})
+
+		It("should skip CRs without securitygroup-uuid label", func() {
+			cr := &v1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sgName,
+					Namespace: sgNamespace,
+					Labels:    map[string]string{},
+				},
+				Spec: v1alpha1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: v1alpha1.SecurityGroupStatus{
+					Phase: v1alpha1.SecurityGroupPhaseReady,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sgName,
+					Namespace: sgNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Assert no Update RPC was called
+			Expect(mockServer.updates).To(BeEmpty())
+		})
+
+		It("should skip CRs being deleted", func() {
+			sg := &privatev1.SecurityGroup{
+				Id: sgID,
+				Metadata: &privatev1.Metadata{
+					Name: sgName,
+				},
+				Spec: &privatev1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: &privatev1.SecurityGroupStatus{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING,
+				},
+			}
+			mockServer.addSecurityGroup(sg)
+
+			now := metav1.Now()
+			cr := &v1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              sgName,
+					Namespace:         sgNamespace,
+					DeletionTimestamp: &now,
+					Labels: map[string]string{
+						osacSecurityGroupIDLabel: sgID,
+					},
+				},
+				Spec: v1alpha1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: v1alpha1.SecurityGroupStatus{
+					Phase: v1alpha1.SecurityGroupPhaseDeleting,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sgName,
+					Namespace: sgNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Assert no Update RPC was called
+			Expect(mockServer.updates).To(BeEmpty())
+		})
+
+		It("should not update if status unchanged", func() {
+			sg := &privatev1.SecurityGroup{
+				Id: sgID,
+				Metadata: &privatev1.Metadata{
+					Name: sgName,
+				},
+				Spec: &privatev1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: &privatev1.SecurityGroupStatus{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				},
+			}
+			mockServer.addSecurityGroup(sg)
+
+			cr := &v1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sgName,
+					Namespace: sgNamespace,
+					Labels: map[string]string{
+						osacSecurityGroupIDLabel: sgID,
+					},
+				},
+				Spec: v1alpha1.SecurityGroupSpec{
+					VirtualNetwork: testVnetRef,
+				},
+				Status: v1alpha1.SecurityGroupStatus{
+					Phase: v1alpha1.SecurityGroupPhaseReady,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sgName,
+					Namespace: sgNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Assert no Update RPC was called (state already READY)
+			Expect(mockServer.updates).To(BeEmpty())
+		})
+	})
+})
+
+// mockSecurityGroupsServer implements privatev1.SecurityGroupsServer for testing
+type mockSecurityGroupsServer struct {
+	privatev1.UnimplementedSecurityGroupsServer
+	mu             sync.Mutex
+	securityGroups map[string]*privatev1.SecurityGroup
+	updates        []*privatev1.SecurityGroup
+}
+
+func (m *mockSecurityGroupsServer) addSecurityGroup(sg *privatev1.SecurityGroup) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.securityGroups[sg.GetId()] = sg
+}
+
+func (m *mockSecurityGroupsServer) Get(ctx context.Context, req *privatev1.SecurityGroupsGetRequest) (*privatev1.SecurityGroupsGetResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sg, ok := m.securityGroups[req.GetId()]
+	if !ok {
+		return nil, fmt.Errorf("security group not found: %s", req.GetId())
+	}
+
+	return &privatev1.SecurityGroupsGetResponse{
+		Object: sg,
+	}, nil
+}
+
+func (m *mockSecurityGroupsServer) Update(ctx context.Context, req *privatev1.SecurityGroupsUpdateRequest) (*privatev1.SecurityGroupsUpdateResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sg := req.GetObject()
+	m.securityGroups[sg.GetId()] = sg
+	m.updates = append(m.updates, sg)
+
+	return &privatev1.SecurityGroupsUpdateResponse{
+		Object: sg,
+	}, nil
+}

--- a/internal/controller/securitygroup_names.go
+++ b/internal/controller/securitygroup_names.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+)
+
+var (
+	osacSecurityGroupIDLabel string = fmt.Sprintf("%s/securitygroup-uuid", osacPrefix)
+)


### PR DESCRIPTION
## Summary
- Implement SecurityGroup feedback controller that syncs K8s CR phase status back to the fulfillment-service API
- Add `securitygroup_names.go` with label constants for SecurityGroup UUID mapping
- Mirror established VirtualNetwork feedback controller pattern (phase-only sync, no backend data)
- Register controller in operator main.go
- Include 7 unit tests covering all phase-to-state mappings

## Test plan
- [x] Unit tests pass (`go test ./internal/controller/...`)
- [ ] Integration tests with fulfillment-service
- [ ] Verify SecurityGroup CR phase changes propagate to API state

🤖 Generated with [Claude Code](https://claude.com/claude-code)