### PR TITLE
MGMT-23633: Fix feedback controller IP propagation

### DIFF
--- a/internal/controller/computeinstance_feedback_controller.go
+++ b/internal/controller/computeinstance_feedback_controller.go
@@ -407,9 +407,15 @@ func (t *computeInstanceFeedbackReconcilerTask) findComputeInstanceCondition(kin
 }
 
 func (t *computeInstanceFeedbackReconcilerTask) syncIPAddress() {
+	// Prefer floating IP from annotation (set by external networking component)
 	ipAddress, ok := t.object.Annotations[osacVirualMachineFloatingIPAddressAnnotation]
 	if ok && ipAddress != "" {
 		t.ci.GetStatus().SetIpAddress(ipAddress)
+		return
+	}
+	// Fall back to the VM's internal IP from CR status
+	if t.object.Status.IPAddress != "" {
+		t.ci.GetStatus().SetIpAddress(t.object.Status.IPAddress)
 	}
 }
 

--- a/internal/controller/computeinstance_feedback_controller_test.go
+++ b/internal/controller/computeinstance_feedback_controller_test.go
@@ -868,6 +868,57 @@ var _ = Describe("ComputeInstanceFeedbackReconciler", func() {
 			Expect(found).To(BeTrue())
 		})
 
+		It("should sync floating IP address from annotation", func() {
+			computeInstance := &osacv1alpha1.ComputeInstance{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
+			computeInstance.Annotations = map[string]string{
+				osacVirualMachineFloatingIPAddressAnnotation: "10.0.0.100",
+			}
+			Expect(k8sClient.Update(ctx, computeInstance)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetIpAddress()).To(Equal("10.0.0.100"))
+		})
+
+		It("should sync internal IP from CR status when no floating IP annotation", func() {
+			computeInstance := &osacv1alpha1.ComputeInstance{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
+			computeInstance.Status.IPAddress = "192.168.1.50"
+			Expect(k8sClient.Status().Update(ctx, computeInstance)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetIpAddress()).To(Equal("192.168.1.50"))
+		})
+
+		It("should prefer floating IP over internal IP when both are set", func() {
+			computeInstance := &osacv1alpha1.ComputeInstance{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
+			computeInstance.Annotations = map[string]string{
+				osacVirualMachineFloatingIPAddressAnnotation: "10.0.0.100",
+			}
+			Expect(k8sClient.Update(ctx, computeInstance)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
+			computeInstance.Status.IPAddress = "192.168.1.50"
+			Expect(k8sClient.Status().Update(ctx, computeInstance)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetIpAddress()).To(Equal("10.0.0.100"))
+		})
+
+		It("should not set IP address when neither floating IP nor internal IP is set", func() {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetIpAddress()).To(BeEmpty())
+		})
+
 		It("should not crash when restart conditions are not present", func() {
 			// RestartInProgress and RestartFailed conditions should not be present by default
 			computeInstance := &osacv1alpha1.ComputeInstance{}


### PR DESCRIPTION
## Summary

- Fixes a bug where the ComputeInstance feedback controller never propagated the VM's internal IP address to the fulfillment service
- The `syncIPAddress()` function only checked the `osac.io/floating-ip-address` annotation (set by external networking components) but ignored `CR.Status.IPAddress` (set by the main reconciler from KubeVirt VMI status)
- Now falls back to `CR.Status.IPAddress` when no floating IP annotation is present

## Test plan

- [x] Added test: sync floating IP from annotation
- [x] Added test: sync internal IP from CR status when no floating IP annotation
- [x] Added test: prefer floating IP over internal IP when both are set
- [x] Added test: no IP set when neither source has one
- [x] All existing tests pass (`ginkgo run -r internal/controller/`)
- [x] `go build` passes
- [x] `gofmt -s -l .` clean

Jira: https://issues.redhat.com/browse/MGMT-23633

🤖 Generated with [Claude Code](https://claude.com/claude-code)