### PR TITLE
MGMT-23662: persist subnet-namespace annotation and refactor annotation handling

### DIFF
--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -53,6 +53,11 @@ const (
 	DefaultStatusPollInterval = 30 * time.Second
 )
 
+// errSubnetNotFound is returned when the Subnet CR referenced by SubnetRef
+// does not exist. handleUpdate treats this as a transient error and requeues
+// with a fixed delay instead of exponential backoff.
+var errSubnetNotFound = errors.New("subnet CR not found")
+
 // ComputeInstanceReconciler reconciles a ComputeInstance object
 type ComputeInstanceReconciler struct {
 	client.Client
@@ -618,22 +623,78 @@ func (r *ComputeInstanceReconciler) resolveSubnetNamespace(ctx context.Context, 
 	return subnetNamespace, nil
 }
 
-func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcile.Request, instance *v1alpha1.ComputeInstance) (ctrl.Result, error) {
+// syncSubnetNamespaceAnnotation ensures the subnet-namespace annotation is set
+// when SubnetRef is configured. SubnetRef is immutable, so the annotation only
+// needs to be resolved and written once; subsequent reconciles reuse the cached
+// annotation value. Returns the resolved namespace, whether the annotation was
+// written, and any error.
+func (r *ComputeInstanceReconciler) syncSubnetNamespaceAnnotation(ctx context.Context, instance *v1alpha1.ComputeInstance) (string, bool, error) {
+	if instance.Spec.SubnetRef == "" {
+		return "", false, nil
+	}
+
+	// SubnetRef is immutable — if the annotation is already set, reuse it.
+	if ns, ok := instance.Annotations[osacSubnetNamespaceAnnotation]; ok {
+		return ns, false, nil
+	}
+
+	subnetNamespace, err := r.resolveSubnetNamespace(ctx, instance)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: %w", errSubnetNotFound, err)
+	}
+	if instance.Annotations == nil {
+		instance.Annotations = make(map[string]string)
+	}
+	instance.Annotations[osacSubnetNamespaceAnnotation] = subnetNamespace
+	return subnetNamespace, true, nil
+}
+
+// syncMetadataPreflight ensures the finalizer is set and the subnet-namespace
+// annotation is in sync with the current SubnetRef.  It batches all metadata
+// changes into a single r.Update() call to avoid multiple round-trips and the
+// status-clobbering problem.  The resolved subnetNamespace is returned so
+// callers can reuse it without a second resolveSubnetNamespace call.
+func (r *ComputeInstanceReconciler) syncMetadataPreflight(ctx context.Context, instance *v1alpha1.ComputeInstance) (string, error) {
 	log := ctrllog.FromContext(ctx)
 
-	if controllerutil.AddFinalizer(instance, osacComputeInstanceFinalizer) {
+	metadataChanged := controllerutil.AddFinalizer(instance, osacComputeInstanceFinalizer)
+
+	subnetNamespace, changed, err := r.syncSubnetNamespaceAnnotation(ctx, instance)
+	if err != nil {
+		log.Error(err, "Failed to resolve subnet namespace")
+		return "", err
+	}
+	if changed {
+		metadataChanged = true
+	}
+
+	if metadataChanged {
 		if err := r.Update(ctx, instance); err != nil {
-			return ctrl.Result{}, err
+			return "", err
 		}
 		// Re-fetch so we have the latest resourceVersion and status; Update() may not
 		// return the full status (status subresource is separate), and we need the
 		// latest version to avoid 409 conflicts on later status updates.
 		if err := r.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
-			return ctrl.Result{}, err
+			return "", err
 		}
 	}
 
-	// Initialize status after the finalizer update, because r.Update() overwrites
+	return subnetNamespace, nil
+}
+
+func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcile.Request, instance *v1alpha1.ComputeInstance) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	subnetNamespace, err := r.syncMetadataPreflight(ctx, instance)
+	if err != nil {
+		if errors.Is(err, errSubnetNotFound) {
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Initialize status after the metadata update, because r.Update() overwrites
 	// the in-memory status with the server response (status subresource is separate).
 	r.initializeStatusConditions(instance)
 	// Initialize phase to Starting for brand-new CIs (Phase is empty until first set).
@@ -662,17 +723,11 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 	}
 
 	// When a subnetRef is set, the VM is created in the subnet namespace
-	// (by the AAP playbook), not in the tenant namespace.
+	// (by the AAP playbook), not in the tenant namespace.  Reuse the value
+	// resolved by syncMetadataPreflight to avoid a redundant API call.
 	vmSearchNamespace := tenant.Status.Namespace
-	if instance.Spec.SubnetRef != "" {
-		subnetNS, err := r.resolveSubnetNamespace(ctx, instance)
-		if err != nil {
-			log.Error(err, "Failed to resolve subnet namespace for VM lookup")
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
-		}
-		if subnetNS != "" {
-			vmSearchNamespace = subnetNS
-		}
+	if subnetNamespace != "" {
+		vmSearchNamespace = subnetNamespace
 	}
 
 	kv, err := r.findKubeVirtVMs(ctx, targetClient, instance, vmSearchNamespace)
@@ -695,23 +750,6 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 
 	if err := r.handleDesiredConfigVersion(ctx, instance); err != nil {
 		return ctrl.Result{}, err
-	}
-
-	// Resolve subnet namespace if subnetRef is set
-	// This must happen before provisioning.TriggerJob so the annotation is available for AAP
-	if instance.Spec.SubnetRef != "" {
-		subnetNamespace, err := r.resolveSubnetNamespace(ctx, instance)
-		if err != nil {
-			log.Error(err, "Failed to resolve subnet namespace")
-			// Return error to retry - Subnet CR might not exist yet
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
-		}
-
-		// Store subnet namespace in annotation for AAP provider to use
-		if instance.Annotations == nil {
-			instance.Annotations = make(map[string]string)
-		}
-		instance.Annotations["osac.openshift.io/subnet-namespace"] = subnetNamespace
 	}
 
 	if err := r.handleReconciledConfigVersion(ctx, instance); err != nil {

--- a/internal/controller/computeinstance_controller_test.go
+++ b/internal/controller/computeinstance_controller_test.go
@@ -1627,13 +1627,149 @@ var _ = Describe("ComputeInstance Controller", func() {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
 			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
 
-			// Reconcile should return error (requeue) when Subnet CR is missing
+			// Reconcile should return RequeueAfter (no error) when Subnet CR is missing
 			result, err := controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{NamespacedName: nn}})
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
 		})
 
-		It("should use tenant namespace when subnetRef is empty", func() {
+		It("should persist subnet-namespace annotation to the API server", func() {
+			const resourceName = "test-ci-subnet-anno-persist"
+			const tenantName = "tenant-subnet-anno-persist"
+			const subnetRef = "test-subnet-anno-persist"
+			defer deleteCI(resourceName)
+			createReadyTenant(ctx, namespaceName, tenantName)
+			defer deleteTenantInNamespace(ctx, namespaceName, tenantName)
+
+			// Create Subnet CR
+			subnet := &osacv1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subnetRef,
+					Namespace: namespaceName,
+				},
+				Spec: osacv1alpha1.SubnetSpec{
+					VirtualNetwork: "vnet-123",
+					IPv4CIDR:       "10.0.0.0/24",
+				},
+			}
+			Expect(k8sClient.Create(ctx, subnet)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, subnet)
+			}()
+
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+
+			// Wait for Subnet CR to be cached by the reconciler's manager cache
+			Eventually(func() error {
+				return controllerReconciler.Client.Get(ctx, types.NamespacedName{Name: subnetRef, Namespace: namespaceName}, &osacv1alpha1.Subnet{})
+			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
+
+			nn := types.NamespacedName{Name: resourceName, Namespace: namespaceName}
+			spec := newTestComputeInstanceSpec("test_template")
+			spec.SubnetRef = subnetRef
+			resource := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: namespaceName,
+					Annotations: map[string]string{
+						osacTenantAnnotation: tenantName,
+					},
+				},
+				Spec: spec,
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			Eventually(func() error {
+				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
+			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
+
+			_, err := controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{NamespacedName: nn}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the annotation was persisted to the API server (not just in-memory)
+			ci := &osacv1alpha1.ComputeInstance{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, nn, ci)).To(Succeed())
+				g.Expect(ci.Annotations).To(HaveKeyWithValue(osacSubnetNamespaceAnnotation, subnetRef))
+			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+		})
+
+		It("should not update annotation when subnet-namespace is already correct", func() {
+			const resourceName = "test-ci-subnet-anno-noop"
+			const tenantName = "tenant-subnet-anno-noop"
+			const subnetRef = "test-subnet-anno-noop"
+			defer deleteCI(resourceName)
+			createReadyTenant(ctx, namespaceName, tenantName)
+			defer deleteTenantInNamespace(ctx, namespaceName, tenantName)
+
+			// Create Subnet CR
+			subnet := &osacv1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subnetRef,
+					Namespace: namespaceName,
+				},
+				Spec: osacv1alpha1.SubnetSpec{
+					VirtualNetwork: "vnet-123",
+					IPv4CIDR:       "10.0.0.0/24",
+				},
+			}
+			Expect(k8sClient.Create(ctx, subnet)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, subnet)
+			}()
+
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+
+			// Wait for Subnet CR to be cached by the reconciler's manager cache
+			Eventually(func() error {
+				return controllerReconciler.Client.Get(ctx, types.NamespacedName{Name: subnetRef, Namespace: namespaceName}, &osacv1alpha1.Subnet{})
+			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
+
+			nn := types.NamespacedName{Name: resourceName, Namespace: namespaceName}
+			spec := newTestComputeInstanceSpec("test_template")
+			spec.SubnetRef = subnetRef
+			resource := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: namespaceName,
+					Annotations: map[string]string{
+						osacTenantAnnotation:          tenantName,
+						osacSubnetNamespaceAnnotation: subnetRef, // already correct
+					},
+				},
+				Spec: spec,
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			Eventually(func() error {
+				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
+			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
+
+			// First reconcile adds the finalizer, which triggers an r.Update().
+			_, err := controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{NamespacedName: nn}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Capture the Generation after the first reconcile. Generation only
+			// increments on spec changes, not on metadata or status updates, so
+			// it stays stable across reconciles that only touch status.
+			ci := &osacv1alpha1.ComputeInstance{}
+			Expect(k8sClient.Get(ctx, nn, ci)).To(Succeed())
+			genBefore := ci.Generation
+			annotationsBefore := ci.Annotations
+
+			// Second reconcile — finalizer and annotation are already in place,
+			// so syncMetadataPreflight should skip the r.Update() call entirely.
+			_, err = controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{NamespacedName: nn}})
+			Expect(err).NotTo(HaveOccurred())
+
+			ciAfter := &osacv1alpha1.ComputeInstance{}
+			Expect(k8sClient.Get(ctx, nn, ciAfter)).To(Succeed())
+			Expect(ciAfter.Annotations).To(HaveKeyWithValue(osacSubnetNamespaceAnnotation, subnetRef))
+			Expect(ciAfter.Generation).To(Equal(genBefore), "Generation should not change when no spec/metadata write occurs")
+			Expect(ciAfter.Annotations).To(Equal(annotationsBefore), "Annotations should be unchanged across reconciles")
+		})
+
+		It("should not set subnet-namespace annotation when subnetRef is empty", func() {
 			const resourceName = "test-ci-no-subnet-vm-ns"
 			const tenantName = "tenant-no-subnet-vm"
 			defer deleteCI(resourceName)
@@ -1667,6 +1803,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, nn, ci)).To(Succeed())
 				g.Expect(ci.Status.Phase).To(Equal(osacv1alpha1.ComputeInstancePhaseStarting))
+				g.Expect(ci.Annotations).NotTo(HaveKey(osacSubnetNamespaceAnnotation))
 			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 		})
 	})

--- a/internal/controller/computeinstance_names.go
+++ b/internal/controller/computeinstance_names.go
@@ -33,4 +33,5 @@ var (
 	osacComputeInstanceManagementStateAnnotation string = fmt.Sprintf("%s/management-state", osacPrefix)
 	osacVirualMachineFloatingIPAddressAnnotation string = fmt.Sprintf("%s/floating-ip-address", osacPrefix)
 	osacAAPReconciledConfigVersionAnnotation     string = fmt.Sprintf("%s/reconciled-config-version", osacPrefix)
+	osacSubnetNamespaceAnnotation                string = fmt.Sprintf("%s/subnet-namespace", osacPrefix)
 )

--- a/internal/controller/securitygroup_controller.go
+++ b/internal/controller/securitygroup_controller.go
@@ -136,12 +136,12 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 	if sg.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
 		sg.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
 		log.Info("setting implementation-strategy annotation", "strategy", implementationStrategy)
-		// Preserve the status we've set since Update returns server state (empty status)
-		currentStatus := sg.Status.DeepCopy()
 		if err := r.Update(ctx, sg); err != nil {
 			return ctrl.Result{}, err
 		}
-		sg.Status = *currentStatus
+		if err := r.Get(ctx, client.ObjectKeyFromObject(sg), sg); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Handle provisioning


### PR DESCRIPTION
## Summary
- Resolve subnet namespace from Subnet CR and persist it as the `osac.openshift.io/subnet-namespace` annotation so downstream reconciliation uses the correct VM search namespace
- Extract `syncSubnetNamespaceAnnotation` into its own method and define `osacSubnetNamespaceAnnotation` in `computeinstance_names.go` for consistency with other annotation variables
- Since `SubnetRef` is immutable, the annotation is resolved once and cached — subsequent reconciles reuse the persisted value without redundant API calls
- Only swallow subnet-not-found errors with a fixed 30s requeue; propagate infrastructure errors (`r.Update`/`r.Get` failures) so controller-runtime applies exponential backoff

## Test plan
- [x] Annotation persistence: reconcile with valid SubnetRef sets annotation on API server
- [x] No-op optimization: second reconcile with unchanged annotation skips `r.Update()` (verified via Generation + Annotations equality)
- [x] Missing Subnet CR: reconcile requeues after 30s without error
- [x] Empty SubnetRef: no subnet-namespace annotation is set
- [x] Existing SubnetRef with Subnet CR: reconcile succeeds with Starting phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Controller now gracefully requeues for 30s when a referenced Subnet is temporarily missing, avoiding failures.
  * ComputeInstance metadata annotation for subnet-namespace is persisted idempotently and reused to reduce redundant lookups.
  * Status updates now use the server-fetched resource after changes to ensure consistent, server-populated fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->