### PR TITLE
MGMT-23402: SecurityGroup implementation-strategy annotation

### DIFF
--- a/internal/controller/securitygroup_controller.go
+++ b/internal/controller/securitygroup_controller.go
@@ -128,6 +128,22 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// Add implementation-strategy annotation if not present or different
+	// This allows AAP playbooks to select the appropriate role without doing lookups
+	if sg.Annotations == nil {
+		sg.Annotations = make(map[string]string)
+	}
+	if sg.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
+		sg.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
+		log.Info("setting implementation-strategy annotation", "strategy", implementationStrategy)
+		// Preserve the status we've set since Update returns server state (empty status)
+		currentStatus := sg.Status.DeepCopy()
+		if err := r.Update(ctx, sg); err != nil {
+			return ctrl.Result{}, err
+		}
+		sg.Status = *currentStatus
+	}
+
 	// Handle provisioning
 	return r.handleProvisioning(ctx, sg, implementationStrategy)
 }

--- a/internal/controller/securitygroup_controller_test.go
+++ b/internal/controller/securitygroup_controller_test.go
@@ -232,6 +232,112 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(provisionTriggered).To(BeTrue())
 		})
 
+		It("should set implementation-strategy annotation from parent VirtualNetwork", func() {
+			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
+
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				return &provisioning.ProvisionResult{
+					JobID:        "job-123",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Job triggered",
+				}, nil
+			}
+
+			// Reconcile twice (first adds finalizer, second sets annotation and provisions)
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Fetch updated SecurityGroup
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
+
+			// Verify annotation was set to match parent VirtualNetwork's ImplementationStrategy
+			Expect(updated.Annotations).NotTo(BeNil())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("cudn-net"))
+		})
+
+		It("should not update when annotation already matches implementation strategy", func() {
+			// Create SecurityGroup with annotation already set
+			sgWithAnnotation := &osacv1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sg-with-annotation",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						osacImplementationStrategyAnnotation: "cudn-net",
+					},
+				},
+				Spec: osacv1alpha1.SecurityGroupSpec{
+					VirtualNetwork: "test-vnet-uuid",
+				},
+			}
+			Expect(fakeClient.Create(ctx, sgWithAnnotation)).To(Succeed())
+
+			key := types.NamespacedName{Name: sgWithAnnotation.Name, Namespace: sgWithAnnotation.Namespace}
+
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				return &provisioning.ProvisionResult{
+					JobID:        "job-456",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Job triggered",
+				}, nil
+			}
+
+			// Reconcile twice
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Fetch updated SecurityGroup
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
+
+			// Verify annotation still matches (no duplicate Update calls)
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("cudn-net"))
+		})
+
+		It("should update annotation when it differs from parent VirtualNetwork", func() {
+			// Create SecurityGroup with different annotation value
+			sgDifferentAnnotation := &osacv1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sg-different-annotation",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						osacImplementationStrategyAnnotation: "old-strategy",
+					},
+				},
+				Spec: osacv1alpha1.SecurityGroupSpec{
+					VirtualNetwork: "test-vnet-uuid",
+				},
+			}
+			Expect(fakeClient.Create(ctx, sgDifferentAnnotation)).To(Succeed())
+
+			key := types.NamespacedName{Name: sgDifferentAnnotation.Name, Namespace: sgDifferentAnnotation.Namespace}
+
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				return &provisioning.ProvisionResult{
+					JobID:        "job-789",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Job triggered",
+				}, nil
+			}
+
+			// Reconcile twice
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Fetch updated SecurityGroup
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
+
+			// Verify annotation was updated to match parent VirtualNetwork
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("cudn-net"))
+		})
+
 		It("should requeue if parent VirtualNetwork has no ImplementationStrategy", func() {
 			// Create VirtualNetwork without ImplementationStrategy
 			vnetNoStrategy := &osacv1alpha1.VirtualNetwork{


### PR DESCRIPTION
## Summary

- Add implementation-strategy annotation propagation to SecurityGroup controller
- SecurityGroup CR now receives `osac.openshift.io/implementation-strategy` from parent VirtualNetwork before AAP provisioning is triggered
- Follows the exact pattern from `subnet_controller.go`

### Details
- Annotation is set in `handleUpdate()` before `handleProvisioning()` is called
- Initializes annotations map if nil (handles fresh CRs)
- Only updates when annotation value differs (idempotent)
- Preserves status during Update to avoid losing Phase/Jobs state
- 3 new unit tests verify annotation behavior

**Jira:** [MGMT-23402](https://issues.redhat.com/browse/MGMT-23402)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SecurityGroups now automatically synchronize an implementation-strategy annotation from their parent VirtualNetwork during reconciliation, ensuring consistent configuration across related resources.

* **Tests**
  * Added test coverage for annotation synchronization, validating behavior across multiple reconciliation passes including initial creation, updates when values differ, and prevention of redundant modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->