### PR TITLE
MGMT-23667: add networking CRDs to kustomization.yaml

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 - bases/osac.openshift.io_hostpools.yaml
 - bases/osac.openshift.io_computeinstances.yaml
 - bases/osac.openshift.io_tenants.yaml
+- bases/osac.openshift.io_securitygroups.yaml
+- bases/osac.openshift.io_virtualnetworks.yaml
+- bases/osac.openshift.io_subnets.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:


### PR DESCRIPTION
## Summary

- The CRD kustomization.yaml was missing 3 networking CRDs (SecurityGroup, VirtualNetwork, Subnet) that exist in config/crd/bases/
- Added the missing entries so all 7 CRDs are deployed when installing the operator

## Test plan

- [x] `kubectl kustomize config/crd/` validates successfully with all 7 CRDs
- [x] All 265 existing controller tests pass
- [x] `go build`, `go vet`, and `gofmt` pass cleanly

Fixes: https://issues.redhat.com/browse/MGMT-23667

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for three new custom resource types: security groups, virtual networks, and subnets to the platform configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->