### PR TITLE
MGMT-23666: add missing networking CRDs to kustomization

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 - bases/osac.openshift.io_hostpools.yaml
 - bases/osac.openshift.io_computeinstances.yaml
 - bases/osac.openshift.io_tenants.yaml
+- bases/osac.openshift.io_securitygroups.yaml
+- bases/osac.openshift.io_virtualnetworks.yaml
+- bases/osac.openshift.io_subnets.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:


### PR DESCRIPTION
## Summary

- The CRD kustomization.yaml only listed 4 CRDs (clusterorders, hostpools, computeinstances, tenants) but was missing the 3 networking CRDs (securitygroups, virtualnetworks, subnets) that have YAML files in the bases directory
- Added the 3 missing CRD entries to the resources section so they are installed when deploying via kustomize

## Test plan

- [x] `kubectl kustomize config/crd/` produces all 7 CRDs
- [x] `go build ./...` passes
- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` passes
- [x] All 262 existing tests pass on origin/main

Fixes: https://issues.redhat.com/browse/MGMT-23666

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced three new custom resource types: SecurityGroups, VirtualNetworks, and Subnets. Users can now define and manage network security policies, virtual networking infrastructure, and subnet configurations as native, first-class resources within OpenShift environments, streamlining infrastructure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->