### PR TITLE
MGMT-23859: fix subnet feedback controller stuck on NotFound during deletion

### DIFF
--- a/internal/controller/subnet_feedback_controller.go
+++ b/internal/controller/subnet_feedback_controller.go
@@ -17,6 +17,8 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
@@ -93,6 +95,13 @@ func (r *SubnetFeedbackReconciler) Reconcile(ctx context.Context, request ctrl.R
 	// Step 3: Fetch the subnet from the fulfillment service so we can compare before/after.
 	subnet, err := r.fetchSubnet(ctx, subnetID)
 	if err != nil {
+		if !object.DeletionTimestamp.IsZero() && status.Code(err) == codes.NotFound {
+			log.Info("Subnet record not found during deletion, removing feedback finalizer", "subnetID", subnetID)
+			if controllerutil.RemoveFinalizer(object, osacSubnetFeedbackFinalizer) {
+				err = r.hubClient.Update(ctx, object)
+			}
+			return result, err
+		}
 		return result, err
 	}
 

--- a/internal/controller/subnet_feedback_controller_test.go
+++ b/internal/controller/subnet_feedback_controller_test.go
@@ -18,14 +18,15 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -501,6 +502,76 @@ var _ = Describe("SubnetFeedbackController", func() {
 			Expect(err).To(HaveOccurred()) // CR should be garbage collected
 		})
 
+		It("should remove feedback finalizer when subnet record is NotFound during deletion", func() {
+			cr := &v1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subnetName,
+					Namespace: subnetNamespace,
+					Labels: map[string]string{
+						osacSubnetIDLabel: subnetID,
+					},
+					Finalizers: []string{osacSubnetFeedbackFinalizer},
+				},
+				Spec: v1alpha1.SubnetSpec{
+					VirtualNetwork: "vnet-123",
+					IPv4CIDR:       "10.0.1.0/24",
+				},
+				Status: v1alpha1.SubnetStatus{
+					Phase: v1alpha1.SubnetPhaseDeleting,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			// Mark for deletion
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      subnetName,
+					Namespace: subnetNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// No gRPC Update or Signal should have been called
+			Expect(mockServer.updates).To(BeEmpty())
+			Expect(mockServer.signals).To(BeEmpty())
+
+			// CR should be gone (finalizer removed, it was the last one)
+			updated := &v1alpha1.Subnet{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: subnetName, Namespace: subnetNamespace}, updated)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error when subnet record is NotFound but CR is not being deleted", func() {
+			cr := &v1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subnetName,
+					Namespace: subnetNamespace,
+					Labels: map[string]string{
+						osacSubnetIDLabel: subnetID,
+					},
+					Finalizers: []string{osacSubnetFeedbackFinalizer},
+				},
+				Spec: v1alpha1.SubnetSpec{
+					VirtualNetwork: "vnet-123",
+					IPv4CIDR:       "10.0.1.0/24",
+				},
+				Status: v1alpha1.SubnetStatus{
+					Phase: v1alpha1.SubnetPhaseReady,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      subnetName,
+					Namespace: subnetNamespace,
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("should not update if status unchanged", func() {
 			ipv4Cidr := testIPv4CIDR
 			subnet := &privatev1.Subnet{
@@ -572,7 +643,7 @@ func (m *mockSubnetsServer) Get(ctx context.Context, req *privatev1.SubnetsGetRe
 
 	subnet, ok := m.subnets[req.GetId()]
 	if !ok {
-		return nil, fmt.Errorf("subnet not found: %s", req.GetId())
+		return nil, grpcstatus.Errorf(codes.NotFound, "object with identifier '%s' not found", req.GetId())
 	}
 
 	return &privatev1.SubnetsGetResponse{


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23859

The subnet feedback controller fetches the subnet record from the fulfillment API before checking deletion state. During deletion the record is already archived, causing NotFound errors that prevent finalizer removal. The CR gets stuck in Deleting forever with only the subnet-feedback finalizer remaining. Handle NotFound when the CR is being deleted by removing the finalizer and returning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource deletion handling to gracefully manage cases where backend records are unavailable, allowing proper cleanup without error propagation
  
* **Tests**
  * Added test cases verifying correct deletion behavior when backend records are missing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->