### PR TITLE
MGMT-23705: propagate virtual network deletion status via feedback controller

### DIFF
--- a/internal/controller/virtualnetwork_feedback_controller.go
+++ b/internal/controller/virtualnetwork_feedback_controller.go
@@ -17,9 +17,12 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/osac-project/osac-operator/api/v1alpha1"
@@ -62,7 +65,7 @@ func (r *VirtualNetworkFeedbackReconciler) SetupWithManager(mgr ctrl.Manager) er
 func (r *VirtualNetworkFeedbackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (result ctrl.Result, err error) {
 	log := ctrllog.FromContext(ctx)
 
-	// Fetch the object to reconcile, and do nothing if it no longer exists:
+	// Step 1: Fetch the object to reconcile, and do nothing if it no longer exists:
 	object := &v1alpha1.VirtualNetwork{}
 	err = r.hubClient.Get(ctx, request.NamespacedName, object)
 	if err != nil {
@@ -70,29 +73,36 @@ func (r *VirtualNetworkFeedbackReconciler) Reconcile(ctx context.Context, reques
 		return //nolint:nakedret
 	}
 
-	// Get the identifier of the virtual network from the labels. If this isn't present it means that the object wasn't
-	// created by the fulfillment service, so we ignore it.
+	// Step 2: Get the identifier of the virtual network from the labels. If this isn't present it means that the object
+	// wasn't created by the fulfillment service, so we ignore it.
 	virtualNetworkID, ok := object.Labels[osacVirtualNetworkIDLabel]
 	if !ok {
+		// If being deleted and somehow has our finalizer, remove it to unblock deletion.
+		if !object.DeletionTimestamp.IsZero() && controllerutil.ContainsFinalizer(object, osacVirtualNetworkFeedbackFinalizer) {
+			log.Info("CR without virtual network ID label is being deleted, removing feedback finalizer")
+			if controllerutil.RemoveFinalizer(object, osacVirtualNetworkFeedbackFinalizer) {
+				err = r.hubClient.Update(ctx, object)
+			}
+			return result, err
+		}
 		log.Info(
 			"There is no label containing the virtual network identifier, will ignore it",
 			"label", osacVirtualNetworkIDLabel,
 		)
-		return
+		return result, err
 	}
 
-	// Check if the VirtualNetwork is being deleted before fetching from fulfillment service
-	if !object.ObjectMeta.DeletionTimestamp.IsZero() {
-		log.Info(
-			"VirtualNetwork is being deleted, skipping feedback reconciliation",
-		)
-		return
-	}
-
-	// Fetch the virtual network:
+	// Step 3: Fetch the virtual network from the fulfillment service so we can compare before/after.
 	virtualNetwork, err := r.fetchVirtualNetwork(ctx, virtualNetworkID)
 	if err != nil {
-		return
+		if !object.DeletionTimestamp.IsZero() && status.Code(err) == codes.NotFound {
+			log.Info("VirtualNetwork record not found during deletion, removing feedback finalizer", "virtualNetworkID", virtualNetworkID)
+			if controllerutil.RemoveFinalizer(object, osacVirtualNetworkFeedbackFinalizer) {
+				err = r.hubClient.Update(ctx, object)
+			}
+			return result, err
+		}
+		return result, err
 	}
 
 	// Create a task to do the rest of the job, but using copies of the objects, so that we can later compare the
@@ -103,14 +113,59 @@ func (r *VirtualNetworkFeedbackReconciler) Reconcile(ctx context.Context, reques
 		virtualNetwork: clone(virtualNetwork),
 	}
 
-	t.handleUpdate(ctx)
+	// Step 4: Sync CR state to the fulfillment service record.
+	// handleUpdate also adds our finalizer; handleDelete syncs state.
+	if object.DeletionTimestamp.IsZero() {
+		err = t.handleUpdate(ctx)
+	} else {
+		t.handleDelete()
+	}
+	if err != nil {
+		return result, err
+	}
 
-	// Save the objects that have changed:
+	// Step 5: Persist synced state to the fulfillment service.
 	err = r.saveVirtualNetwork(ctx, virtualNetwork, t.virtualNetwork)
 	if err != nil {
-		return
+		return result, err
 	}
-	return
+
+	// Step 6: Handle finalizer removal and signal for deletions. This must happen after step 5 so the
+	// deletion state is persisted before the CR is garbage collected.
+	if !object.DeletionTimestamp.IsZero() && controllerutil.ContainsFinalizer(object, osacVirtualNetworkFeedbackFinalizer) {
+		if len(object.GetFinalizers()) == 1 {
+			// We're the last finalizer. Remove it to trigger CR garbage collection, then signal the
+			// fulfillment service to immediately re-reconcile.
+			log.Info(
+				"Feedback finalizer is last remaining, removing finalizer and signaling",
+				"virtualNetworkID", virtualNetworkID,
+			)
+			if controllerutil.RemoveFinalizer(object, osacVirtualNetworkFeedbackFinalizer) {
+				err = r.hubClient.Update(ctx, object)
+				if err != nil {
+					return result, err
+				}
+			}
+			_, signalErr := r.virtualNetworksClient.Signal(ctx, privatev1.VirtualNetworksSignalRequest_builder{
+				Id: virtualNetworkID,
+			}.Build())
+			if signalErr != nil {
+				log.Error(
+					signalErr,
+					"Failed to signal fulfillment service, periodic sync will handle cleanup",
+					"virtualNetworkID", virtualNetworkID,
+				)
+			}
+		} else {
+			// Other finalizers still present — another controller hasn't finished cleanup yet.
+			log.Info(
+				"Other finalizers still present, waiting",
+				"finalizers", object.GetFinalizers(),
+			)
+		}
+	}
+
+	return result, err
 }
 
 func (r *VirtualNetworkFeedbackReconciler) fetchVirtualNetwork(ctx context.Context, id string) (virtualNetwork *privatev1.VirtualNetwork, err error) {
@@ -149,8 +204,27 @@ func (r *VirtualNetworkFeedbackReconciler) saveVirtualNetwork(ctx context.Contex
 	return nil
 }
 
-func (t *virtualNetworkFeedbackReconcilerTask) handleUpdate(ctx context.Context) {
+// handleUpdate ensures our finalizer is present and syncs the CR state to the
+// fulfillment service. Called when the CR is not being deleted.
+func (t *virtualNetworkFeedbackReconcilerTask) handleUpdate(ctx context.Context) error {
+	if controllerutil.AddFinalizer(t.object, osacVirtualNetworkFeedbackFinalizer) {
+		if err := t.r.hubClient.Update(ctx, t.object); err != nil {
+			return err
+		}
+	}
 	t.syncPhase(ctx)
+	return nil
+}
+
+// handleDelete syncs the deletion phase to the fulfillment service.
+// VN proto has no DELETING/DELETE_FAILED states, so Deleting maps to PENDING
+// and Failed maps to FAILED.
+func (t *virtualNetworkFeedbackReconcilerTask) handleDelete() {
+	if t.object.Status.Phase == v1alpha1.VirtualNetworkPhaseFailed {
+		t.virtualNetwork.GetStatus().SetState(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_FAILED)
+		return
+	}
+	t.virtualNetwork.GetStatus().SetState(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING)
 }
 
 func (t *virtualNetworkFeedbackReconcilerTask) syncPhase(ctx context.Context) {

--- a/internal/controller/virtualnetwork_feedback_controller_test.go
+++ b/internal/controller/virtualnetwork_feedback_controller_test.go
@@ -25,13 +25,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/osac-project/osac-operator/api/v1alpha1"
@@ -67,6 +70,7 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 		mockServer = &mockVirtualNetworksServer{
 			virtualNetworks: make(map[string]*privatev1.VirtualNetwork),
 			updates:         make([]*privatev1.VirtualNetwork, 0),
+			signals:         make([]string, 0),
 		}
 		listener = bufconn.Listen(1024 * 1024)
 		grpcServer = grpc.NewServer()
@@ -149,6 +153,11 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 			// Assert gRPC Update called with state=READY
 			Expect(mockServer.updates).To(HaveLen(1))
 			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY))
+
+			// Assert finalizer was added
+			updated := &v1alpha1.VirtualNetwork{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vnetName, Namespace: vnetNamespace}, updated)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(updated, osacVirtualNetworkFeedbackFinalizer)).To(BeTrue())
 		})
 
 		It("should sync Phase=Progressing to database state=PENDING", func() {
@@ -247,54 +256,6 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_FAILED))
 		})
 
-		It("should sync Phase=Deleting to database state=PENDING", func() {
-			ipv4Cidr := testIPv4CIDR
-			vnet := &privatev1.VirtualNetwork{
-				Id: vnetID,
-				Metadata: &privatev1.Metadata{
-					Name: vnetName,
-				},
-				Spec: &privatev1.VirtualNetworkSpec{
-					NetworkClass: "udn-net",
-					Ipv4Cidr:     &ipv4Cidr,
-				},
-				Status: &privatev1.VirtualNetworkStatus{
-					State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
-				},
-			}
-			mockServer.addVirtualNetwork(vnet)
-
-			cr := &v1alpha1.VirtualNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vnetName,
-					Namespace: vnetNamespace,
-					Labels: map[string]string{
-						osacVirtualNetworkIDLabel: vnetID,
-					},
-				},
-				Spec: v1alpha1.VirtualNetworkSpec{
-					Region:       "us-west-1",
-					NetworkClass: "udn-net",
-					IPv4CIDR:     "10.0.0.0/16",
-				},
-				Status: v1alpha1.VirtualNetworkStatus{
-					Phase: v1alpha1.VirtualNetworkPhaseDeleting,
-				},
-			}
-			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      vnetName,
-					Namespace: vnetNamespace,
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(mockServer.updates).To(HaveLen(1))
-			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING))
-		})
-
 		It("should skip CRs without virtualnetwork-uuid label", func() {
 			cr := &v1alpha1.VirtualNetwork{
 				ObjectMeta: metav1.ObjectMeta{
@@ -325,7 +286,7 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 			Expect(mockServer.updates).To(BeEmpty())
 		})
 
-		It("should skip CRs being deleted", func() {
+		It("should sync Phase=Deleting during deletion and keep finalizer when others present", func() {
 			ipv4Cidr := testIPv4CIDR
 			vnet := &privatev1.VirtualNetwork{
 				Id: vnetID,
@@ -337,20 +298,20 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 					Ipv4Cidr:     &ipv4Cidr,
 				},
 				Status: &privatev1.VirtualNetworkStatus{
-					State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING,
+					State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
 				},
 			}
 			mockServer.addVirtualNetwork(vnet)
 
-			now := metav1.Now()
+			// Create CR with finalizer first (simulating a previously reconciled CR)
 			cr := &v1alpha1.VirtualNetwork{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              vnetName,
-					Namespace:         vnetNamespace,
-					DeletionTimestamp: &now,
+					Name:      vnetName,
+					Namespace: vnetNamespace,
 					Labels: map[string]string{
 						osacVirtualNetworkIDLabel: vnetID,
 					},
+					Finalizers: []string{osacVirtualNetworkFeedbackFinalizer, osacVirtualNetworkFinalizer},
 				},
 				Spec: v1alpha1.VirtualNetworkSpec{
 					Region:       "us-west-1",
@@ -363,6 +324,9 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
 
+			// Mark for deletion
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      vnetName,
@@ -371,8 +335,251 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Assert no Update RPC was called
+			// Assert Update RPC was called with PENDING state (VN has no DELETING state)
+			Expect(mockServer.updates).To(HaveLen(1))
+			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING))
+
+			// Feedback finalizer should still be present (other finalizers remain)
+			updated := &v1alpha1.VirtualNetwork{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vnetName, Namespace: vnetNamespace}, updated)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(updated, osacVirtualNetworkFeedbackFinalizer)).To(BeTrue())
+		})
+
+		It("should sync Phase=Failed during deletion to database state=FAILED", func() {
+			ipv4Cidr := testIPv4CIDR
+			vnet := &privatev1.VirtualNetwork{
+				Id: vnetID,
+				Metadata: &privatev1.Metadata{
+					Name: vnetName,
+				},
+				Spec: &privatev1.VirtualNetworkSpec{
+					NetworkClass: "udn-net",
+					Ipv4Cidr:     &ipv4Cidr,
+				},
+				Status: &privatev1.VirtualNetworkStatus{
+					State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
+				},
+			}
+			mockServer.addVirtualNetwork(vnet)
+
+			cr := &v1alpha1.VirtualNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+					Labels: map[string]string{
+						osacVirtualNetworkIDLabel: vnetID,
+					},
+					Finalizers: []string{osacVirtualNetworkFeedbackFinalizer, osacVirtualNetworkFinalizer},
+				},
+				Spec: v1alpha1.VirtualNetworkSpec{
+					Region:       "us-west-1",
+					NetworkClass: "udn-net",
+					IPv4CIDR:     "10.0.0.0/16",
+				},
+				Status: v1alpha1.VirtualNetworkStatus{
+					Phase: v1alpha1.VirtualNetworkPhaseFailed,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockServer.updates).To(HaveLen(1))
+			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_FAILED))
+		})
+
+		It("should still remove finalizer when signal fails", func() {
+			ipv4Cidr := testIPv4CIDR
+			vnet := &privatev1.VirtualNetwork{
+				Id: vnetID,
+				Metadata: &privatev1.Metadata{
+					Name: vnetName,
+				},
+				Spec: &privatev1.VirtualNetworkSpec{
+					NetworkClass: "udn-net",
+					Ipv4Cidr:     &ipv4Cidr,
+				},
+				Status: &privatev1.VirtualNetworkStatus{
+					State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
+				},
+			}
+			mockServer.addVirtualNetwork(vnet)
+			mockServer.signalErr = fmt.Errorf("signal unavailable")
+
+			cr := &v1alpha1.VirtualNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+					Labels: map[string]string{
+						osacVirtualNetworkIDLabel: vnetID,
+					},
+					Finalizers: []string{osacVirtualNetworkFeedbackFinalizer},
+				},
+				Spec: v1alpha1.VirtualNetworkSpec{
+					Region:       "us-west-1",
+					NetworkClass: "udn-net",
+					IPv4CIDR:     "10.0.0.0/16",
+				},
+				Status: v1alpha1.VirtualNetworkStatus{
+					Phase: v1alpha1.VirtualNetworkPhaseDeleting,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &v1alpha1.VirtualNetwork{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: vnetName, Namespace: vnetNamespace}, updated)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should remove feedback finalizer and signal when it is the last finalizer", func() {
+			ipv4Cidr := testIPv4CIDR
+			vnet := &privatev1.VirtualNetwork{
+				Id: vnetID,
+				Metadata: &privatev1.Metadata{
+					Name: vnetName,
+				},
+				Spec: &privatev1.VirtualNetworkSpec{
+					NetworkClass: "udn-net",
+					Ipv4Cidr:     &ipv4Cidr,
+				},
+				Status: &privatev1.VirtualNetworkStatus{
+					State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
+				},
+			}
+			mockServer.addVirtualNetwork(vnet)
+
+			// Create CR with only feedback finalizer (simulating other finalizers already removed)
+			cr := &v1alpha1.VirtualNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+					Labels: map[string]string{
+						osacVirtualNetworkIDLabel: vnetID,
+					},
+					Finalizers: []string{osacVirtualNetworkFeedbackFinalizer},
+				},
+				Spec: v1alpha1.VirtualNetworkSpec{
+					Region:       "us-west-1",
+					NetworkClass: "udn-net",
+					IPv4CIDR:     "10.0.0.0/16",
+				},
+				Status: v1alpha1.VirtualNetworkStatus{
+					Phase: v1alpha1.VirtualNetworkPhaseDeleting,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			// Mark for deletion
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Assert Update RPC was called with PENDING state (VN has no DELETING state)
+			Expect(mockServer.updates).To(HaveLen(1))
+			Expect(mockServer.updates[0].GetStatus().GetState()).To(Equal(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING))
+
+			// Assert Signal RPC was called
+			Expect(mockServer.signals).To(HaveLen(1))
+			Expect(mockServer.signals[0]).To(Equal(vnetID))
+
+			// Assert finalizer was removed (CR should be gone since it was the last finalizer)
+			updated := &v1alpha1.VirtualNetwork{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: vnetName, Namespace: vnetNamespace}, updated)
+			Expect(err).To(HaveOccurred()) // CR should be garbage collected
+		})
+
+		It("should remove feedback finalizer when VN record is NotFound during deletion", func() {
+			cr := &v1alpha1.VirtualNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+					Labels: map[string]string{
+						osacVirtualNetworkIDLabel: vnetID,
+					},
+					Finalizers: []string{osacVirtualNetworkFeedbackFinalizer},
+				},
+				Spec: v1alpha1.VirtualNetworkSpec{
+					Region:       "us-west-1",
+					NetworkClass: "udn-net",
+					IPv4CIDR:     "10.0.0.0/16",
+				},
+				Status: v1alpha1.VirtualNetworkStatus{
+					Phase: v1alpha1.VirtualNetworkPhaseDeleting,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			// Mark for deletion
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// No gRPC Update or Signal should have been called
 			Expect(mockServer.updates).To(BeEmpty())
+			Expect(mockServer.signals).To(BeEmpty())
+
+			// CR should be gone (finalizer removed, it was the last one)
+			updated := &v1alpha1.VirtualNetwork{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: vnetName, Namespace: vnetNamespace}, updated)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error when VN record is NotFound but CR is not being deleted", func() {
+			cr := &v1alpha1.VirtualNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+					Labels: map[string]string{
+						osacVirtualNetworkIDLabel: vnetID,
+					},
+					Finalizers: []string{osacVirtualNetworkFeedbackFinalizer},
+				},
+				Spec: v1alpha1.VirtualNetworkSpec{
+					Region:       "us-west-1",
+					NetworkClass: "udn-net",
+					IPv4CIDR:     "10.0.0.0/16",
+				},
+				Status: v1alpha1.VirtualNetworkStatus{
+					Phase: v1alpha1.VirtualNetworkPhaseReady,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vnetName,
+					Namespace: vnetNamespace,
+				},
+			})
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should not update if status unchanged", func() {
@@ -399,6 +606,7 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 					Labels: map[string]string{
 						osacVirtualNetworkIDLabel: vnetID,
 					},
+					Finalizers: []string{osacVirtualNetworkFeedbackFinalizer},
 				},
 				Spec: v1alpha1.VirtualNetworkSpec{
 					Region:       "us-west-1",
@@ -419,7 +627,7 @@ var _ = Describe("VirtualNetworkFeedbackController", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Assert no Update RPC was called (state already READY)
+			// Assert no Update RPC was called (state already READY, finalizer pre-seeded)
 			Expect(mockServer.updates).To(BeEmpty())
 		})
 	})
@@ -431,6 +639,8 @@ type mockVirtualNetworksServer struct {
 	mu              sync.Mutex
 	virtualNetworks map[string]*privatev1.VirtualNetwork
 	updates         []*privatev1.VirtualNetwork
+	signals         []string
+	signalErr       error
 }
 
 func (m *mockVirtualNetworksServer) addVirtualNetwork(vnet *privatev1.VirtualNetwork) {
@@ -445,7 +655,7 @@ func (m *mockVirtualNetworksServer) Get(ctx context.Context, req *privatev1.Virt
 
 	vnet, ok := m.virtualNetworks[req.GetId()]
 	if !ok {
-		return nil, fmt.Errorf("virtual network not found: %s", req.GetId())
+		return nil, grpcstatus.Errorf(codes.NotFound, "object with identifier '%s' not found", req.GetId())
 	}
 
 	return &privatev1.VirtualNetworksGetResponse{
@@ -464,4 +674,16 @@ func (m *mockVirtualNetworksServer) Update(ctx context.Context, req *privatev1.V
 	return &privatev1.VirtualNetworksUpdateResponse{
 		Object: vnet,
 	}, nil
+}
+
+func (m *mockVirtualNetworksServer) Signal(ctx context.Context, req *privatev1.VirtualNetworksSignalRequest) (*privatev1.VirtualNetworksSignalResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.signals = append(m.signals, req.GetId())
+
+	if m.signalErr != nil {
+		return nil, m.signalErr
+	}
+	return &privatev1.VirtualNetworksSignalResponse{}, nil
 }

--- a/internal/controller/virtualnetwork_names.go
+++ b/internal/controller/virtualnetwork_names.go
@@ -21,5 +21,6 @@ import (
 )
 
 var (
-	osacVirtualNetworkIDLabel string = fmt.Sprintf("%s/virtualnetwork-uuid", osacPrefix)
+	osacVirtualNetworkIDLabel           string = fmt.Sprintf("%s/virtualnetwork-uuid", osacPrefix)
+	osacVirtualNetworkFeedbackFinalizer string = fmt.Sprintf("%s/virtualnetwork-feedback", osacPrefix)
 )


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23705

Add finalizer management, deletion state sync, and NotFound handling to the virtual network feedback controller matching the subnet feedback controller pattern. Without this, deletion failures are never propagated back to the fulfillment API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual network deletion handling to ensure custom resources can be properly cleaned up.
  * Enhanced error handling when fulfillment service records are unavailable or missing.
  * Fixed synchronization between deletion operations to properly signal service state changes.
  * Strengthened finalizer management to prevent incomplete deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->