### PR TITLE
MGMT-23392: Add VMaaS dedicated cluster documentation

### DIFF
--- a/docs/vmaas-dedicated-cluster/README.md
+++ b/docs/vmaas-dedicated-cluster/README.md
@@ -1,0 +1,151 @@
+# VMaaS Dedicated Cluster
+
+The OSAC operator can manage KubeVirt VMs on a **remote cluster** that is
+separate from the cluster where the operator itself runs. This allows all VMs
+to be deployed to a dedicated VMaaS cluster while the operator, fulfillment
+service, and AAP remain on the management cluster.
+
+## Motivation
+
+This feature was originally designed for the
+[Enclave](https://github.com/rh-ecosystem-edge/enclave) use case, where the
+control plane (fulfillment service, osac-operator, and AAP) and the VMaaS
+cluster are managed by different personas.
+
+## Architecture
+
+| Controller | Local cluster | VMaaS cluster (remote) |
+|---|---|---|
+| ComputeInstance controller | reconciles ComputeInstance CRs | watch KubeVirt VirtualMachine/VirtualMachineInstance |
+| Tenant controller | reconciles Tenant CRs | manage Tenant namespace, UDN resources |
+| AAP | | manage KubeVirt VirtualMachine/VirtualMachineInstance |
+
+The `ComputeInstance` and `Tenant` custom resources remain on the management
+cluster. Their controllers reconcile those resources locally and watch the
+downstream Kubernetes objects (VMs, namespaces, UDN) on the remote cluster
+via a dedicated kubeconfig.
+
+osac-operator relies on
+[multicluster-runtime](https://github.com/kubernetes-sigs/multicluster-runtime)
+to watch and manage resources across both clusters. AAP relies on the
+standard [kubernetes.core](https://github.com/ansible-collections/kubernetes.core)
+Ansible collection, passing a kubeconfig to each task to target the remote
+cluster.
+
+The `ClusterOrder` and `HostPool` controllers are local-only and are
+incompatible with the remote cluster option (see [Constraints](#constraints)).
+
+## Configuration
+
+### osac-operator
+
+The operator accepts a kubeconfig path that points to the remote cluster. When
+set, the `ComputeInstance` and `Tenant` controllers target the remote cluster
+instead of the local one.
+
+| Flag | Environment variable | Default | Description |
+|---|---|---|---|
+| `--remote-cluster-kubeconfig` | `OSAC_REMOTE_CLUSTER_KUBECONFIG` | _(unset)_ | Path to a kubeconfig file for the remote VMaaS cluster. When unset the operator behaves as before (single-cluster mode). |
+| `--enable-tenant-controller` | `OSAC_ENABLE_TENANT_CONTROLLER` | `false` | Enable the Tenant controller. |
+| `--enable-compute-instance-controller` | `OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER` | `false` | Enable the ComputeInstance controller. |
+
+> **Note:** When no `--enable-*-controller` flag is set, the operator enables
+> all controllers by default. When using a remote cluster, at least one of
+> `--enable-tenant-controller` or `--enable-compute-instance-controller` must
+> be set explicitly to avoid also enabling the controllers that are
+> incompatible with the remote cluster option.
+
+The kubeconfig is typically provided to the operator pod as a mounted
+Kubernetes Secret volume.
+
+#### Example: operator deployment with remote cluster
+
+```yaml
+env:
+  - name: OSAC_REMOTE_CLUSTER_KUBECONFIG
+    value: /etc/osac/remote-cluster-kubeconfig
+  - name: OSAC_ENABLE_TENANT_CONTROLLER
+    value: "true"
+  - name: OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER
+    value: "true"
+volumeMounts:
+  - name: remote-cluster-kubeconfig
+    mountPath: /etc/osac
+    readOnly: true
+volumes:
+  - name: remote-cluster-kubeconfig
+    secret:
+      secretName: <secret-name>
+      items:
+        - key: kubeconfig
+          path: remote-cluster-kubeconfig
+```
+
+### AAP (osac-aap)
+
+The `compute-instance-operations-ig` instance group is configured via two
+variables that control whether the Ansible execution environment gets access
+to the remote cluster kubeconfig.
+
+| Variable | Environment variable | Default | Description |
+|---|---|---|---|
+| `remote_cluster_kubeconfig_secret_name` | `REMOTE_CLUSTER_KUBECONFIG_SECRET_NAME` | _(unset)_ | Name of the Kubernetes Secret holding the remote cluster kubeconfig. When unset, no remote cluster is configured for AAP jobs. |
+| `remote_cluster_kubeconfig_secret_key` | `REMOTE_CLUSTER_KUBECONFIG_SECRET_KEY` | `kubeconfig` | Key within the Secret that contains the kubeconfig data. |
+
+When `remote_cluster_kubeconfig_secret_name` is set:
+
+1. The Secret is mounted into the `compute-instance-operations-ig` worker
+   pod at `/etc/osac`.
+2. `OSAC_REMOTE_CLUSTER_KUBECONFIG=/etc/osac/remote-cluster-kubeconfig` is
+   injected as an environment variable.
+3. The `ocp_virt_vm` Ansible role reads that variable at task start (via
+   `get_remote_cluster_kubeconfig.yaml`) and passes `kubeconfig: <path>` to
+   every `kubernetes.core.k8s` and `kubernetes.core.k8s_info` task,
+   directing all VM operations to the remote cluster.
+
+## Setup
+
+### 1. Create the kubeconfig Secret
+
+On the management cluster, create a Secret containing the remote cluster
+kubeconfig:
+
+```bash
+kubectl create secret generic <secret-name> \
+  --from-file=kubeconfig=/path/to/remote-cluster.kubeconfig \
+  -n <osac-namespace>
+```
+
+### 2. Configure the operator
+
+Set `OSAC_REMOTE_CLUSTER_KUBECONFIG` and mount the Secret (see example
+above). Enable only the controllers that should run against the remote cluster
+(`tenant` and/or `compute-instance`). The `ClusterOrder` and `HostPool`
+controllers, if needed, must run in a separate operator instance without the
+remote kubeconfig.
+
+### 3. Configure AAP
+
+Pass `REMOTE_CLUSTER_KUBECONFIG_SECRET_NAME=<secret-name>` to the
+config-as-code job (or set it in the relevant config vars). The Secret must
+be readable by the `osac-sa` service account in the AAP namespace.
+
+## References
+
+- [MGMT-23102](https://redhat.atlassian.net/browse/MGMT-23102) — Add the
+  ability to manage VMs remotely
+- [osac-project/osac-operator#119](https://github.com/osac-project/osac-operator/pull/119)
+  — Multicluster support and controller refactor
+- [osac-project/osac-aap#209](https://github.com/osac-project/osac-aap/pull/209)
+  — Add optional keys to specify a remote cluster
+- [osac-project/osac-aap#213](https://github.com/osac-project/osac-aap/pull/213)
+  — Re-vendor to get compute instance remote cluster support
+
+## Constraints
+
+- `--remote-cluster-kubeconfig` is **incompatible** with
+  `--enable-host-pool-controller` and `--enable-cluster-controller`. The
+  operator will exit with an error if both are set simultaneously. Run those
+  controllers in a separate operator instance without the remote kubeconfig.
+- When no remote kubeconfig is configured, the operator operates in
+  single-cluster mode with no behaviour change.

--- a/docs/vmaas-dedicated-cluster/README.md
+++ b/docs/vmaas-dedicated-cluster/README.md
@@ -18,7 +18,7 @@ cluster are managed by different personas.
 |---|---|---|
 | ComputeInstance controller | reconciles ComputeInstance CRs | watch KubeVirt VirtualMachine/VirtualMachineInstance |
 | Tenant controller | reconciles Tenant CRs | manage Tenant namespace, UDN resources |
-| AAP | | manage KubeVirt VirtualMachine/VirtualMachineInstance |
+| AAP | executes playbooks | manage KubeVirt VirtualMachine/VirtualMachineInstance |
 
 The `ComputeInstance` and `Tenant` custom resources remain on the management
 cluster. Their controllers reconcile those resources locally and watch the

--- a/docs/vmaas-dedicated-cluster/README.md
+++ b/docs/vmaas-dedicated-cluster/README.md
@@ -32,8 +32,8 @@ standard [kubernetes.core](https://github.com/ansible-collections/kubernetes.cor
 Ansible collection, passing a kubeconfig to each task to target the remote
 cluster.
 
-The `ClusterOrder` and `HostPool` controllers are local-only and are
-incompatible with the remote cluster option (see [Constraints](#constraints)).
+Other controllers are local-only and incompatible with the remote cluster
+option (see [Constraints](#constraints)).
 
 ## Configuration
 
@@ -120,9 +120,8 @@ kubectl create secret generic <secret-name> \
 
 Set `OSAC_REMOTE_CLUSTER_KUBECONFIG` and mount the Secret (see example
 above). Enable only the controllers that should run against the remote cluster
-(`tenant` and/or `compute-instance`). The `ClusterOrder` and `HostPool`
-controllers, if needed, must run in a separate operator instance without the
-remote kubeconfig.
+(`tenant` and/or `compute-instance`). Other controllers, if needed, must run
+in a separate operator instance without the remote kubeconfig.
 
 ### 3. Configure AAP
 
@@ -143,9 +142,9 @@ be readable by the `osac-sa` service account in the AAP namespace.
 
 ## Constraints
 
-- `--remote-cluster-kubeconfig` is **incompatible** with
-  `--enable-host-pool-controller` and `--enable-cluster-controller`. The
-  operator will exit with an error if both are set simultaneously. Run those
-  controllers in a separate operator instance without the remote kubeconfig.
+- `--remote-cluster-kubeconfig` is only compatible with the `tenant` and
+  `compute-instance` controllers. The operator will exit with an error if
+  other controllers are enabled alongside it. Run those in a separate
+  operator instance without the remote kubeconfig.
 - When no remote kubeconfig is configured, the operator operates in
   single-cluster mode with no behaviour change.

--- a/docs/vmaas-dedicated-cluster/README.md
+++ b/docs/vmaas-dedicated-cluster/README.md
@@ -45,7 +45,7 @@ instead of the local one.
 
 | Flag | Environment variable | Default | Description |
 |---|---|---|---|
-| `--remote-cluster-kubeconfig` | `OSAC_REMOTE_CLUSTER_KUBECONFIG` | _(unset)_ | Path to a kubeconfig file for the remote VMaaS cluster. When unset the operator behaves as before (single-cluster mode). |
+| `--remote-cluster-kubeconfig` | `OSAC_REMOTE_CLUSTER_KUBECONFIG` | _(unset)_ | Path to a kubeconfig file for the remote VMaaS cluster. When unset the operator behaves in single-cluster mode. |
 | `--enable-tenant-controller` | `OSAC_ENABLE_TENANT_CONTROLLER` | `false` | Enable the Tenant controller. |
 | `--enable-compute-instance-controller` | `OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER` | `false` | Enable the ComputeInstance controller. |
 

--- a/docs/vmaas-dedicated-cluster/README.md
+++ b/docs/vmaas-dedicated-cluster/README.md
@@ -14,7 +14,7 @@ cluster are managed by different personas.
 
 ## Architecture
 
-| Controller | Local cluster | VMaaS cluster (remote) |
+| Controller | Management cluster | VMaaS cluster (remote) |
 |---|---|---|
 | ComputeInstance controller | reconciles ComputeInstance CRs | watch KubeVirt VirtualMachine/VirtualMachineInstance |
 | Tenant controller | reconciles Tenant CRs | manage Tenant namespace, UDN resources |


### PR DESCRIPTION
## Summary

- Add `docs/vmaas-dedicated-cluster/README.md` documenting the multi-cluster feature
- Covers motivation (Enclave use case), architecture, configuration for both osac-operator and AAP, setup steps, constraints, and references to the originating PRs and ticket

## References

- [MGMT-23392](https://redhat.atlassian.net/browse/MGMT-23392)
- [MGMT-23102](https://redhat.atlassian.net/browse/MGMT-23102)
- osac-project/osac-operator#119
- osac-project/osac-aap#209
- osac-project/osac-aap#213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for running VM management against a separate remote VMaaS cluster, including architecture, setup steps, operator and orchestration configuration for using a remote kubeconfig, instructions for provisioning the kubeconfig secret, and example deployment snippets.
  * Clarifies supported controllers and compatibility constraints when using remote mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->