### PR TITLE
feat: migrate ComputeInstance and ClusterOrder to RunProvisioningLifecycle [MGMT-24106]

### DIFF
--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -522,8 +522,6 @@ func (r *ClusterOrderReconciler) handleDelete(ctx context.Context, _ reconcile.R
 	return ctrl.Result{}, nil
 }
 
-// handleProvisioning manages the provisioning job lifecycle for ClusterOrder.
-// Uses shouldTriggerProvision to decide action, with API server read-through guard.
 func (r *ClusterOrderReconciler) provisionState(instance *v1alpha1.ClusterOrder) *provisioning.State {
 	return &provisioning.State{
 		Jobs:                 &instance.Status.Jobs,
@@ -540,34 +538,19 @@ func (r *ClusterOrderReconciler) handleProvisioning(ctx context.Context, instanc
 		return ctrl.Result{}, nil
 	}
 
-	provState := r.provisionState(instance)
-	action, latestProvisionJob := r.shouldTriggerProvision(ctx, instance)
-	trigger := func() (ctrl.Result, error) {
-		return provisioning.TriggerJob(ctx, r.ProvisioningProvider, instance, provState, r.MaxJobHistory, r.StatusPollInterval)
-	}
-
-	switch action {
-	case provisioning.Skip:
-		return ctrl.Result{}, nil
-	case provisioning.Requeue:
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	case provisioning.Trigger:
-		return trigger()
-	case provisioning.Backoff:
-		return provisioning.HandleBackoff(ctx, provState, latestProvisionJob, trigger)
-	default: // provisioning.Poll
-		return provisioning.PollJob(ctx, r.ProvisioningProvider, instance, provState, latestProvisionJob, r.StatusPollInterval, &provisioning.PollCallbacks{
+	return provisioning.RunProvisioningLifecycle(ctx, r.ProvisioningProvider, instance,
+		r.provisionState(instance),
+		r.MaxJobHistory, r.StatusPollInterval,
+		&provisioning.PollCallbacks{
 			OnFailed: func(_ string) {
 				instance.Status.Phase = v1alpha1.ClusterOrderPhaseFailed
 			},
-		})
-	}
-}
-
-func (r *ClusterOrderReconciler) shouldTriggerProvision(ctx context.Context, instance *v1alpha1.ClusterOrder) (provisioning.Action, *v1alpha1.JobStatus) {
-	return provisioning.EvaluateAction(r.provisionState(instance), func() bool {
-		return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, r.apiReader, client.ObjectKeyFromObject(instance), &v1alpha1.ClusterOrder{})
-	})
+		},
+		func() bool {
+			return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, r.apiReader, client.ObjectKeyFromObject(instance), &v1alpha1.ClusterOrder{})
+		},
+		func() error { return r.Status().Update(ctx, instance) },
+	)
 }
 
 func (r *ClusterOrderReconciler) handleDesiredConfigVersion(instance *v1alpha1.ClusterOrder) error {

--- a/internal/controller/clusterorder_controller_test.go
+++ b/internal/controller/clusterorder_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
@@ -87,20 +88,18 @@ var _ = Describe("ClusterOrder Controller", func() {
 		})
 	})
 
-	Context("shouldTriggerProvision", func() {
-		var reconciler *ClusterOrderReconciler
-
-		BeforeEach(func() {
-			noopWebhookClient := &noopWebhookClientForTest{}
-			reconciler = &ClusterOrderReconciler{
-				Client:               k8sClient,
-				apiReader:            k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ProvisioningProvider: provisioning.NewEDAProvider(noopWebhookClient, "http://noop-create", "http://noop-delete"),
-			}
-		})
-
+	Context("EvaluateAction (formerly shouldTriggerProvision)", func() {
 		ctx := context.Background()
+
+		evaluateAction := func(instance *v1alpha1.ClusterOrder) (provisioning.Action, *v1alpha1.JobStatus) {
+			provState := &provisioning.State{
+				Jobs:                 &instance.Status.Jobs,
+				DesiredConfigVersion: instance.Status.DesiredConfigVersion,
+			}
+			return provisioning.EvaluateAction(provState, func() bool {
+				return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, k8sClient, client.ObjectKeyFromObject(instance), &v1alpha1.ClusterOrder{})
+			})
+		}
 
 		It("should trigger when no job exists and config versions differ", func() {
 			instance := &v1alpha1.ClusterOrder{
@@ -108,7 +107,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					DesiredConfigVersion: "abc123",
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Trigger))
 			Expect(job).To(BeNil())
 		})
@@ -120,7 +119,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					Jobs:                 []v1alpha1.JobStatus{{Type: v1alpha1.JobTypeProvision, JobID: ""}},
 				},
 			}
-			action, _ := reconciler.shouldTriggerProvision(ctx, instance)
+			action, _ := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Trigger))
 		})
 
@@ -130,7 +129,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					DesiredConfigVersion: "abc123",
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Trigger))
 			Expect(job).To(BeNil())
 		})
@@ -141,7 +140,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					Jobs: []v1alpha1.JobStatus{{Type: v1alpha1.JobTypeProvision, JobID: "job-1", State: v1alpha1.JobStateRunning}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Poll))
 			Expect(job).NotTo(BeNil())
 			Expect(job.JobID).To(Equal("job-1"))
@@ -153,7 +152,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					Jobs: []v1alpha1.JobStatus{{Type: v1alpha1.JobTypeProvision, JobID: "job-1", State: v1alpha1.JobStatePending}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Poll))
 			Expect(job).NotTo(BeNil())
 		})
@@ -165,7 +164,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					Jobs:                 []v1alpha1.JobStatus{{Type: v1alpha1.JobTypeProvision, JobID: "job-1", State: v1alpha1.JobStateSucceeded, ConfigVersion: "abc123"}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Skip))
 			Expect(job).NotTo(BeNil())
 		})
@@ -177,7 +176,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					Jobs:                 []v1alpha1.JobStatus{{Type: v1alpha1.JobTypeProvision, JobID: "job-1", State: v1alpha1.JobStateSucceeded, ConfigVersion: "old-version"}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Trigger))
 			Expect(job).NotTo(BeNil())
 		})
@@ -189,7 +188,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					Jobs:                 []v1alpha1.JobStatus{{Type: v1alpha1.JobTypeProvision, JobID: "job-1", State: v1alpha1.JobStateFailed, ConfigVersion: "old-version"}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Trigger))
 			Expect(job).NotTo(BeNil())
 		})
@@ -206,7 +205,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Skip))
 			Expect(job).NotTo(BeNil())
 		})
@@ -223,7 +222,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Backoff))
 			Expect(job).NotTo(BeNil())
 		})
@@ -240,7 +239,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Trigger))
 			Expect(job).NotTo(BeNil())
 		})
@@ -257,7 +256,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 					}},
 				},
 			}
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			action, job := evaluateAction(instance)
 			Expect(action).To(Equal(provisioning.Trigger))
 			Expect(job).NotTo(BeNil())
 		})
@@ -285,7 +284,6 @@ var _ = Describe("ClusterOrder Controller", func() {
 			}
 			Expect(k8sClient.Status().Update(ctx, apiInstance)).To(Succeed())
 
-			// Simulate stale cache: in-memory instance has no jobs
 			staleInstance := &v1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      instanceName,
@@ -296,7 +294,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 				},
 			}
 
-			action, job := reconciler.shouldTriggerProvision(ctx, staleInstance)
+			action, job := evaluateAction(staleInstance)
 			Expect(action).To(Equal(provisioning.Requeue))
 			Expect(job).To(BeNil())
 		})

--- a/internal/controller/clusterorder_integration_test.go
+++ b/internal/controller/clusterorder_integration_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 	"github.com/osac-project/osac-operator/internal/provisioning"
@@ -172,7 +173,13 @@ var _ = Describe("ClusterOrder Integration Tests", func() {
 				},
 			}
 
-			action, _ := reconciler.shouldTriggerProvision(ctx, staleInstance)
+			provState := &provisioning.State{
+				Jobs:                 &staleInstance.Status.Jobs,
+				DesiredConfigVersion: staleInstance.Status.DesiredConfigVersion,
+			}
+			action, _ := provisioning.EvaluateAction(provState, func() bool {
+				return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, k8sClient, client.ObjectKeyFromObject(staleInstance), &osacv1alpha1.ClusterOrder{})
+			})
 			Expect(action).To(Equal(provisioning.Requeue), "should detect non-terminal job via API server and requeue")
 		})
 	})
@@ -249,7 +256,13 @@ var _ = Describe("ClusterOrder Integration Tests", func() {
 				{Type: osacv1alpha1.JobTypeProvision, JobID: "job-1", State: osacv1alpha1.JobStateSucceeded, ConfigVersion: "v1"},
 			}
 
-			action, job := reconciler.shouldTriggerProvision(ctx, instance)
+			provState := &provisioning.State{
+				Jobs:                 &instance.Status.Jobs,
+				DesiredConfigVersion: instance.Status.DesiredConfigVersion,
+			}
+			action, job := provisioning.EvaluateAction(provState, func() bool {
+				return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, k8sClient, client.ObjectKeyFromObject(instance), &osacv1alpha1.ClusterOrder{})
+			})
 			Expect(action).To(Equal(provisioning.Skip))
 			Expect(job).NotTo(BeNil())
 		})

--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -321,8 +321,8 @@ func (r *ComputeInstanceReconciler) mapTenantToComputeInstances(ctx context.Cont
 }
 
 // handleProvisioning manages the provisioning job lifecycle for a ComputeInstance.
-// It triggers provisioning if needed and polls job status until completion.
-// Status updates are handled by the main reconcile loop.
+// Uses shared RunProvisioningLifecycle with statusFlush to prevent duplicate jobs
+// from concurrent reconciliations.
 func (r *ComputeInstanceReconciler) handleProvisioning(ctx context.Context, instance *v1alpha1.ComputeInstance) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
 
@@ -339,24 +339,10 @@ func (r *ComputeInstanceReconciler) handleProvisioning(ctx context.Context, inst
 		return ctrl.Result{}, nil
 	}
 
-	provState := r.provisionState(instance)
-	action, latestProvisionJob := r.shouldTriggerProvision(ctx, instance)
-	trigger := func() (ctrl.Result, error) {
-		return provisioning.TriggerJob(ctx, r.ProvisioningProvider, instance, provState, r.MaxJobHistory, r.StatusPollInterval)
-	}
-
-	switch action {
-	case provisioning.Skip:
-		return ctrl.Result{}, nil
-	case provisioning.Trigger:
-		return trigger()
-	case provisioning.Requeue:
-		// Use RequeueAfter (not Requeue: true) to avoid hammering the API server
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	case provisioning.Backoff:
-		return provisioning.HandleBackoff(ctx, provState, latestProvisionJob, trigger)
-	default: // provisioning.Poll
-		return provisioning.PollJob(ctx, r.ProvisioningProvider, instance, provState, latestProvisionJob, r.StatusPollInterval, &provisioning.PollCallbacks{
+	return provisioning.RunProvisioningLifecycle(ctx, r.ProvisioningProvider, instance,
+		r.provisionState(instance),
+		r.MaxJobHistory, r.StatusPollInterval,
+		&provisioning.PollCallbacks{
 			OnFailed: func(_ string) {
 				// Only set Failed phase if no VM exists yet (first-time provisioning failure).
 				// If the VM already exists (re-provisioning failure), the phase is driven by KubeVirt
@@ -368,10 +354,17 @@ func (r *ComputeInstanceReconciler) handleProvisioning(ctx context.Context, inst
 			IsCompleted: func() bool {
 				// EDA's GetProvisionStatus always returns Unknown.
 				// Detect completion by checking if the VM was created on the cluster.
-				return provisioning.IsEDAJobID(latestProvisionJob.JobID) && instance.Status.VirtualMachineReference != nil
+				latestJob := provisioning.FindLatestJobByType(instance.Status.Jobs, v1alpha1.JobTypeProvision)
+				return latestJob != nil && provisioning.IsEDAJobID(latestJob.JobID) && instance.Status.VirtualMachineReference != nil
 			},
-		})
-	}
+		},
+		func() bool {
+			return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, r.mgr.GetLocalManager().GetAPIReader(), client.ObjectKeyFromObject(instance), &v1alpha1.ComputeInstance{})
+		},
+		func() error {
+			return r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(instance), instance.Status)
+		},
+	)
 }
 
 // handleDeprovisioning manages the deprovisioning job lifecycle for a ComputeInstance.
@@ -955,22 +948,11 @@ func determinePhaseFromPrintableStatus(ctx context.Context, kv *kubevirtv1.Virtu
 	}
 }
 
-// shouldTriggerProvision determines the next provisioning action.
-// Returns provisioning.Poll with the in-progress job when one is already running.
-// Returns provisioning.Skip when config versions match (no change needed).
-// Returns provisioning.Requeue when the API server has a non-terminal job that the cache missed (stale cache).
-// Returns provisioning.Trigger when provisioning is needed and no in-flight job exists.
 func (r *ComputeInstanceReconciler) provisionState(instance *v1alpha1.ComputeInstance) *provisioning.State {
 	return &provisioning.State{
 		Jobs:                 &instance.Status.Jobs,
 		DesiredConfigVersion: instance.Status.DesiredConfigVersion,
 	}
-}
-
-func (r *ComputeInstanceReconciler) shouldTriggerProvision(ctx context.Context, instance *v1alpha1.ComputeInstance) (provisioning.Action, *v1alpha1.JobStatus) {
-	return provisioning.EvaluateAction(r.provisionState(instance), func() bool {
-		return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, r.mgr.GetLocalManager().GetAPIReader(), client.ObjectKeyFromObject(instance), &v1alpha1.ComputeInstance{})
-	})
 }
 
 // handleDesiredConfigVersion sets status.desiredConfigVersion to the hash of spec.

--- a/internal/controller/computeinstance_controller_test.go
+++ b/internal/controller/computeinstance_controller_test.go
@@ -673,12 +673,16 @@ var _ = Describe("ComputeInstance Controller", func() {
 			})
 		})
 
-		Describe("shouldTriggerProvision", func() {
-			var reconciler *ComputeInstanceReconciler
-
-			BeforeEach(func() {
-				reconciler = NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
-			})
+		Describe("EvaluateAction (formerly shouldTriggerProvision)", func() {
+			evaluateAction := func(instance *osacv1alpha1.ComputeInstance) (provisioning.Action, *osacv1alpha1.JobStatus) {
+				provState := &provisioning.State{
+					Jobs:                 &instance.Status.Jobs,
+					DesiredConfigVersion: instance.Status.DesiredConfigVersion,
+				}
+				return provisioning.EvaluateAction(provState, func() bool {
+					return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, k8sClient, client.ObjectKeyFromObject(instance), &osacv1alpha1.ComputeInstance{})
+				})
+			}
 
 			It("should trigger when no job exists and config versions differ", func() {
 				instance := &osacv1alpha1.ComputeInstance{
@@ -686,7 +690,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						DesiredConfigVersion: "abc123",
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Trigger))
 				Expect(job).To(BeNil())
 			})
@@ -698,7 +702,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						Jobs:                 []osacv1alpha1.JobStatus{{Type: osacv1alpha1.JobTypeProvision, JobID: ""}},
 					},
 				}
-				action, _ := reconciler.shouldTriggerProvision(ctx, instance)
+				action, _ := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Trigger))
 			})
 
@@ -708,7 +712,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						Jobs: []osacv1alpha1.JobStatus{{Type: osacv1alpha1.JobTypeProvision, JobID: "job-1", State: osacv1alpha1.JobStateRunning}},
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Poll))
 				Expect(job).NotTo(BeNil())
 				Expect(job.JobID).To(Equal("job-1"))
@@ -720,7 +724,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						Jobs: []osacv1alpha1.JobStatus{{Type: osacv1alpha1.JobTypeProvision, JobID: "job-1", State: osacv1alpha1.JobStatePending}},
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Poll))
 				Expect(job).NotTo(BeNil())
 			})
@@ -732,7 +736,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						Jobs:                 []osacv1alpha1.JobStatus{{Type: osacv1alpha1.JobTypeProvision, JobID: "job-1", State: osacv1alpha1.JobStateSucceeded, ConfigVersion: "abc123"}},
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Skip))
 				Expect(job).NotTo(BeNil())
 			})
@@ -744,7 +748,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						Jobs:                 []osacv1alpha1.JobStatus{{Type: osacv1alpha1.JobTypeProvision, JobID: "job-1", State: osacv1alpha1.JobStateSucceeded, ConfigVersion: "old-version"}},
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Trigger))
 				Expect(job).NotTo(BeNil())
 			})
@@ -756,7 +760,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						Jobs:                 []osacv1alpha1.JobStatus{{Type: osacv1alpha1.JobTypeProvision, JobID: "job-1", State: osacv1alpha1.JobStateFailed, ConfigVersion: "old-version"}},
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Trigger))
 				Expect(job).NotTo(BeNil())
 			})
@@ -768,7 +772,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 						Jobs:                 []osacv1alpha1.JobStatus{{Type: osacv1alpha1.JobTypeProvision, JobID: "job-1", State: osacv1alpha1.JobStateFailed, ConfigVersion: "abc123"}},
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Backoff))
 				Expect(job).NotTo(BeNil())
 			})
@@ -787,13 +791,12 @@ var _ = Describe("ComputeInstance Controller", func() {
 						}},
 					},
 				}
-				action, job := reconciler.shouldTriggerProvision(ctx, instance)
+				action, job := evaluateAction(instance)
 				Expect(action).To(Equal(provisioning.Backoff))
 				Expect(job).NotTo(BeNil())
 			})
 
 			It("should requeue when API server has non-terminal job but cache shows none", func() {
-				// Create instance in API server with a running provision job
 				instanceName := "test-api-server-check-no-cache"
 				apiInstance := &osacv1alpha1.ComputeInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -814,7 +817,6 @@ var _ = Describe("ComputeInstance Controller", func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, apiInstance)).To(Succeed())
 
-				// Simulate stale cache: in-memory instance has no jobs
 				staleInstance := &osacv1alpha1.ComputeInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      instanceName,
@@ -825,13 +827,12 @@ var _ = Describe("ComputeInstance Controller", func() {
 					},
 				}
 
-				action, job := reconciler.shouldTriggerProvision(ctx, staleInstance)
+				action, job := evaluateAction(staleInstance)
 				Expect(action).To(Equal(provisioning.Requeue))
 				Expect(job).To(BeNil())
 			})
 
 			It("should requeue when API server has non-terminal job but cache shows terminal job with version mismatch", func() {
-				// Create instance in API server with a running provision job (newer than the terminal one)
 				instanceName := "test-api-server-check-stale-terminal"
 				apiInstance := &osacv1alpha1.ComputeInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -854,7 +855,6 @@ var _ = Describe("ComputeInstance Controller", func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, apiInstance)).To(Succeed())
 
-				// Simulate stale cache: in-memory instance only has the old terminal job
 				staleInstance := &osacv1alpha1.ComputeInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      instanceName,
@@ -868,13 +868,12 @@ var _ = Describe("ComputeInstance Controller", func() {
 					},
 				}
 
-				action, job := reconciler.shouldTriggerProvision(ctx, staleInstance)
+				action, job := evaluateAction(staleInstance)
 				Expect(action).To(Equal(provisioning.Requeue))
 				Expect(job).To(BeNil())
 			})
 
 			It("should trigger when API server also shows no non-terminal job", func() {
-				// Create instance in API server with only a terminal job
 				instanceName := "test-api-server-check-all-terminal"
 				apiInstance := &osacv1alpha1.ComputeInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -895,7 +894,6 @@ var _ = Describe("ComputeInstance Controller", func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, apiInstance)).To(Succeed())
 
-				// In-memory instance matches API server — terminal job, ConfigVersion differs from desired
 				staleInstance := &osacv1alpha1.ComputeInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      instanceName,
@@ -909,7 +907,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 					},
 				}
 
-				action, job := reconciler.shouldTriggerProvision(ctx, staleInstance)
+				action, job := evaluateAction(staleInstance)
 				Expect(action).To(Equal(provisioning.Trigger))
 				Expect(job).NotTo(BeNil())
 				Expect(job.JobID).To(Equal("done-job"))

--- a/internal/controller/computeinstance_integration_test.go
+++ b/internal/controller/computeinstance_integration_test.go
@@ -195,10 +195,7 @@ var _ = Describe("ComputeInstance Integration Tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(100 * time.Millisecond))
 
-			// Update status to persist the job ID
-			Expect(k8sClient.Status().Update(ctx, instance)).To(Succeed())
-
-			// Verify job was triggered
+			// Re-fetch: RunProvisioningLifecycle flushes status after trigger
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: testNamespace}, instance)).To(Succeed())
 			latestProvisionJob := provisioning.FindLatestJobByType(instance.Status.Jobs, osacv1alpha1.JobTypeProvision)
 			Expect(latestProvisionJob).NotTo(BeNil())
@@ -261,7 +258,9 @@ var _ = Describe("ComputeInstance Integration Tests", func() {
 			// Trigger the job
 			_, err := reconciler.handleProvisioning(ctx, instance)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(k8sClient.Status().Update(ctx, instance)).To(Succeed())
+
+			// Re-fetch: RunProvisioningLifecycle flushes status after trigger
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: testNamespace}, instance)).To(Succeed())
 
 			// Simulate job failing
 			provider.setProvisionJobState(osacv1alpha1.JobStateFailed, "Provisioning failed")


### PR DESCRIPTION
## Summary

- Refactored ComputeInstance and ClusterOrder controllers to use the shared `RunProvisioningLifecycle` function instead of inline switch statements over `EvaluateAction`, eliminating three separate code paths for the same provisioning lifecycle
- Wired `statusFlush` callbacks in both controllers to persist job status immediately after trigger, preventing the duplicate-job race condition ([MGMT-24003](https://redhat.atlassian.net/browse/MGMT-24003)) in all controllers — not just networking ones
- Preserved controller-specific callbacks: ComputeInstance's conditional `OnFailed` (only sets Failed phase if no VM exists) and `IsCompleted` (EDA detection), and ClusterOrder's simple `OnFailed`

Closes [MGMT-24106](https://issues.redhat.com/browse/MGMT-24106)

Related: [MGMT-24003](https://redhat.atlassian.net/browse/MGMT-24003) (original fix for networking controllers)

## Test plan

- [x] All 277 existing unit and integration tests pass
- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `gofmt -s -l .` reports no formatting issues
- [ ] Verify no duplicate AAP jobs triggered during ComputeInstance provisioning in a dev environment
- [ ] Verify no duplicate AAP jobs triggered during ClusterOrder provisioning in a dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provisioning job state synchronization with the API server to prevent stale cache issues.
  * Enhanced status updates during the provisioning lifecycle to ensure accurate job tracking.
  * Fixed handling of non-terminal provisioning jobs to prevent duplicate triggers and race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->