### PR TITLE
MGMT-23977: Implement per-tier StorageClass resolution in Tenant controller

### DIFF
--- a/api/v1alpha1/tenant_types.go
+++ b/api/v1alpha1/tenant_types.go
@@ -49,11 +49,9 @@ const (
 
 // Reason constants for Tenant conditions
 const (
-	TenantReasonFound                 = "Found"
-	TenantReasonNotFound              = "NotFound"
-	TenantReasonSharedDefault         = "SharedDefault"
-	TenantReasonMultipleFound         = "MultipleFound"
-	TenantReasonMultipleDefaultsFound = "MultipleDefaultsFound"
+	TenantReasonFound         = "Found"
+	TenantReasonNotFound      = "NotFound"
+	TenantReasonMultipleFound = "MultipleFound"
 )
 
 // ResolvedStorageClass captures a single resolved StorageClass for a specific

--- a/internal/controller/tenant_controller.go
+++ b/internal/controller/tenant_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	ovnv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
@@ -144,46 +145,56 @@ func (r *TenantReconciler) handleUpdate(ctx context.Context, req reconcile.Reque
 		v1alpha1.TenantReasonFound,
 		fmt.Sprintf("Namespace %q found on target cluster", instance.GetName()))
 
-	// Prerequisite 2: valid StorageClass (tenant-specific or shared Default)
-	scResult, err := r.getTenantStorageClass(ctx, targetClient, instance.GetName())
+	// Prerequisite 2: resolve all storage tiers
+	result, err := r.getTenantStorageClasses(ctx, targetClient, instance.GetName())
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if scResult.name == "" {
+	for _, msg := range result.duplicateMessages {
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, eventReasonDuplicateStorageClass, eventActionDetectDuplicate, "%s", msg)
+	}
+
+	if len(result.resolved) == 0 {
+		reason := v1alpha1.TenantReasonNotFound
+		if len(result.duplicateMessages) > 0 {
+			reason = v1alpha1.TenantReasonMultipleFound
+		}
+		condMsg := result.conditionMessage()
 		instance.SetStatusCondition(v1alpha1.TenantConditionStorageClassReady,
 			metav1.ConditionFalse,
-			scResult.reason,
-			scResult.message)
-		if scResult.reason == v1alpha1.TenantReasonMultipleFound || scResult.reason == v1alpha1.TenantReasonMultipleDefaultsFound {
-			r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, eventReasonDuplicateStorageClass, eventActionDetectDuplicate, "%s", scResult.message)
-		}
+			reason,
+			condMsg)
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, eventReasonStorageClassNotReady, "StorageClassResolution", "%s", condMsg)
 		return ctrl.Result{}, nil
 	}
 
 	instance.SetStatusCondition(v1alpha1.TenantConditionStorageClassReady,
 		metav1.ConditionTrue,
-		scResult.reason,
-		scResult.message)
+		v1alpha1.TenantReasonFound,
+		result.conditionMessage())
 
 	instance.Status.Namespace = namespace.GetName()
-	instance.Status.StorageClass = scResult.name
-	instance.Status.StorageClasses = []v1alpha1.ResolvedStorageClass{
-		{Name: scResult.name, Tier: scResult.tier},
-	}
+	instance.Status.StorageClass = result.resolved[0].Name
+	instance.Status.StorageClasses = result.resolved
 	instance.Status.Phase = v1alpha1.TenantPhaseReady
 
 	return ctrl.Result{}, nil
 }
 
-// storageClassResult holds the outcome of a StorageClass lookup, including
-// the resolved name (empty if none found) and the reason/message for the
-// condition that should be set on the Tenant.
-type storageClassResult struct {
-	name    string
-	tier    string
-	reason  string
-	message string
+// tierResolutionResult holds the outcome of resolving all storage tiers for a tenant.
+type tierResolutionResult struct {
+	resolved          []v1alpha1.ResolvedStorageClass
+	resolvedMessages  []string
+	errorMessages     []string
+	duplicateMessages []string
+}
+
+func (r *tierResolutionResult) conditionMessage() string {
+	parts := make([]string, 0, len(r.resolvedMessages)+len(r.errorMessages))
+	parts = append(parts, r.resolvedMessages...)
+	parts = append(parts, r.errorMessages...)
+	return strings.Join(parts, "; ")
 }
 
 // storageTierFromLabel reads the osac.openshift.io/storage-tier label from a
@@ -206,79 +217,107 @@ func joinStorageClassNames(items []storagev1.StorageClass) (joined string, names
 	return strings.Join(names, ", "), names
 }
 
-// getTenantStorageClass looks up the StorageClass for a tenant using a two-step
-// fallback: tenant-specific SC first, then shared Default SC. Returns a
-// storageClassResult with the resolved name and condition metadata. A non-nil
-// error is only returned for API call failures.
-func (r *TenantReconciler) getTenantStorageClass(ctx context.Context, targetClient client.Client, tenantName string) (storageClassResult, error) {
+// groupByTier groups StorageClasses by their osac.openshift.io/storage-tier label value.
+// StorageClasses missing the label are ignored.
+func groupByTier(scList []storagev1.StorageClass) map[string][]storagev1.StorageClass {
+	groups := make(map[string][]storagev1.StorageClass)
+	for _, sc := range scList {
+		tier, exists := sc.GetLabels()[osacStorageTierLabel]
+		if !exists || tier == "" {
+			continue
+		}
+		groups[strings.ToLower(tier)] = append(groups[strings.ToLower(tier)], sc)
+	}
+	return groups
+}
+
+// getTenantStorageClasses resolves all storage tiers for a tenant. For each
+// distinct storage-tier value found across tenant-specific and shared Default
+// StorageClasses, it applies a two-step fallback per tier: tenant-specific first,
+// then shared Default. StorageClasses missing the storage-tier label are ignored.
+func (r *TenantReconciler) getTenantStorageClasses(ctx context.Context, targetClient client.Client, tenantName string) (tierResolutionResult, error) {
 	log := ctrllog.FromContext(ctx)
 
-	// Step 1 — Tenant-specific StorageClasses (label osac.openshift.io/tenant=<tenantName>).
-	// Exactly one → use it. More than one → error (do not consider Default SC). Zero → Step 2.
 	tenantSCList := &storagev1.StorageClassList{}
 	if err := targetClient.List(ctx, tenantSCList, client.MatchingLabels{osacTenantAnnotation: tenantName}); err != nil {
-		return storageClassResult{}, err
+		return tierResolutionResult{}, err
 	}
 
-	switch len(tenantSCList.Items) {
-	case 1:
-		sc := &tenantSCList.Items[0]
-		return storageClassResult{
-			name:    sc.GetName(),
-			tier:    storageTierFromLabel(sc),
-			reason:  v1alpha1.TenantReasonFound,
-			message: fmt.Sprintf("StorageClass %q found for tenant %q", sc.GetName(), tenantName),
-		}, nil
-	case 0:
-		// No tenant SCs — evaluate shared Default SCs (Step 2) below.
-	default:
-		joined, names := joinStorageClassNames(tenantSCList.Items)
-		msg := fmt.Sprintf("Multiple StorageClasses found for tenant %q: [%s]. Exactly one is required; remove the extras to resolve.",
-			tenantName, joined)
-		log.Info(msg, "tenant", tenantName, "storageClasses", names)
-		return storageClassResult{
-			reason:  v1alpha1.TenantReasonMultipleFound,
-			message: msg,
-		}, nil
-	}
-
-	// Step 2 — Shared Default StorageClasses (label osac.openshift.io/tenant=Default).
-	// Only reached when Step 1 found zero tenant-specific SCs.
 	defaultSCList := &storagev1.StorageClassList{}
 	if err := targetClient.List(ctx, defaultSCList, client.MatchingLabels{osacTenantAnnotation: defaultStorageClassSentinel}); err != nil {
-		return storageClassResult{}, err
+		return tierResolutionResult{}, err
 	}
 
-	switch len(defaultSCList.Items) {
-	case 1:
-		sc := &defaultSCList.Items[0]
-		msg := fmt.Sprintf("No tenant-specific StorageClass found for tenant %q. "+
-			"Using shared Default StorageClass %q. Storage is not isolated for this tenant.",
-			tenantName, sc.GetName())
-		log.Info(msg)
-		return storageClassResult{
-			name:    sc.GetName(),
-			tier:    storageTierFromLabel(sc),
-			reason:  v1alpha1.TenantReasonSharedDefault,
-			message: msg,
-		}, nil
-	case 0:
-		msg := fmt.Sprintf("No StorageClass found for tenant %q (no tenant SC, no Default SC)", tenantName)
-		log.Info(msg)
-		return storageClassResult{
-			reason:  v1alpha1.TenantReasonNotFound,
-			message: msg,
-		}, nil
-	default:
-		joined, names := joinStorageClassNames(defaultSCList.Items)
-		msg := fmt.Sprintf("Multiple shared Default StorageClasses found: [%s]. Exactly one is required; remove the extras to resolve. Tenant %q has no dedicated StorageClass and is affected.",
-			joined, tenantName)
-		log.Info(msg, "tenant", tenantName, "storageClasses", names)
-		return storageClassResult{
-			reason:  v1alpha1.TenantReasonMultipleDefaultsFound,
-			message: msg,
-		}, nil
+	tenantByTier := groupByTier(tenantSCList.Items)
+	defaultByTier := groupByTier(defaultSCList.Items)
+
+	allTiers := make(map[string]struct{})
+	for t := range tenantByTier {
+		allTiers[t] = struct{}{}
 	}
+	for t := range defaultByTier {
+		allTiers[t] = struct{}{}
+	}
+
+	sortedTiers := make([]string, 0, len(allTiers))
+	for t := range allTiers {
+		sortedTiers = append(sortedTiers, t)
+	}
+	sort.Strings(sortedTiers)
+
+	var result tierResolutionResult
+
+	for _, tier := range sortedTiers {
+		tenantSCs := tenantByTier[tier]
+		defaultSCs := defaultByTier[tier]
+
+		switch len(tenantSCs) {
+		case 1:
+			scName := tenantSCs[0].GetName()
+			result.resolved = append(result.resolved, v1alpha1.ResolvedStorageClass{
+				Name: scName,
+				Tier: tier,
+			})
+			msg := fmt.Sprintf("tier %q: StorageClass %q (tenant-specific)", tier, scName)
+			result.resolvedMessages = append(result.resolvedMessages, msg)
+			continue
+		case 0:
+			// Fall through to Default resolution below.
+		default:
+			joined, names := joinStorageClassNames(tenantSCs)
+			msg := fmt.Sprintf("tier %q: multiple tenant StorageClasses [%s]", tier, joined)
+			log.Info(msg, "tenant", tenantName, "tier", tier, "storageClasses", names)
+			result.errorMessages = append(result.errorMessages, msg)
+			result.duplicateMessages = append(result.duplicateMessages, msg)
+			continue
+		}
+
+		switch len(defaultSCs) {
+		case 1:
+			scName := defaultSCs[0].GetName()
+			result.resolved = append(result.resolved, v1alpha1.ResolvedStorageClass{
+				Name: scName,
+				Tier: tier,
+			})
+			msg := fmt.Sprintf("tier %q: StorageClass %q (shared Default)", tier, scName)
+			result.resolvedMessages = append(result.resolvedMessages, msg)
+		case 0:
+			// Tier not available — not an error at the Tenant level.
+		default:
+			joined, names := joinStorageClassNames(defaultSCs)
+			msg := fmt.Sprintf("tier %q: multiple shared Default StorageClasses [%s]", tier, joined)
+			log.Info(msg, "tenant", tenantName, "tier", tier, "storageClasses", names)
+			result.errorMessages = append(result.errorMessages, msg)
+			result.duplicateMessages = append(result.duplicateMessages, msg)
+		}
+	}
+
+	if len(result.resolved) == 0 && len(result.errorMessages) == 0 {
+		result.errorMessages = append(result.errorMessages,
+			fmt.Sprintf("no StorageClasses with %s label found for tenant %q", osacStorageTierLabel, tenantName))
+	}
+
+	return result, nil
 }
 
 // mapStorageClassToTenant maps a StorageClass event to Tenant reconcile requests.

--- a/internal/controller/tenant_controller.go
+++ b/internal/controller/tenant_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -197,15 +198,9 @@ func (r *tierResolutionResult) conditionMessage() string {
 	return strings.Join(parts, "; ")
 }
 
-// storageTierFromLabel reads the osac.openshift.io/storage-tier label from a
-// StorageClass, normalized to lowercase. Returns "default" if the label is
-// absent or empty.
-func storageTierFromLabel(sc *storagev1.StorageClass) string {
-	if tier := sc.GetLabels()[osacStorageTierLabel]; tier != "" {
-		return strings.ToLower(tier)
-	}
-	return "default"
-}
+// tierLabelPattern matches values that conform to the ResolvedStorageClass.Tier
+// CRD validation: lowercase alphanumeric with dashes, dots, underscores, 1-63 chars.
+var tierLabelPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
 
 // joinStorageClassNames returns StorageClass metadata names as a comma-separated string for
 // messages and the same values as a slice for structured logging.
@@ -218,15 +213,20 @@ func joinStorageClassNames(items []storagev1.StorageClass) (joined string, names
 }
 
 // groupByTier groups StorageClasses by their osac.openshift.io/storage-tier label value.
-// StorageClasses missing the label are ignored.
+// StorageClasses missing the label or with values that don't match the CRD tier
+// pattern (after lowercase normalization) are ignored.
 func groupByTier(scList []storagev1.StorageClass) map[string][]storagev1.StorageClass {
 	groups := make(map[string][]storagev1.StorageClass)
 	for _, sc := range scList {
-		tier, exists := sc.GetLabels()[osacStorageTierLabel]
-		if !exists || tier == "" {
+		raw, exists := sc.GetLabels()[osacStorageTierLabel]
+		if !exists || raw == "" {
 			continue
 		}
-		groups[strings.ToLower(tier)] = append(groups[strings.ToLower(tier)], sc)
+		tier := strings.ToLower(raw)
+		if !tierLabelPattern.MatchString(tier) {
+			continue
+		}
+		groups[tier] = append(groups[tier], sc)
 	}
 	return groups
 }

--- a/internal/controller/tenant_controller_test.go
+++ b/internal/controller/tenant_controller_test.go
@@ -118,9 +118,11 @@ var _ = Describe("Tenant Controller", func() {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, tenant)).To(Succeed())
 					g.Expect(tenant.Status.Phase).To(Equal(expectedPhase))
 					if expectedSCs == nil {
+						g.Expect(tenant.Status.StorageClass).To(BeEmpty())
 						g.Expect(tenant.Status.StorageClasses).To(BeNil())
 					} else {
 						g.Expect(tenant.Status.StorageClasses).To(ConsistOf(expectedSCs))
+						g.Expect(tenant.Status.StorageClass).To(Equal(expectedSCs[0].Name))
 					}
 
 					nsCond := tenant.GetStatusCondition(v1alpha1.TenantConditionNamespaceReady)

--- a/internal/controller/tenant_controller_test.go
+++ b/internal/controller/tenant_controller_test.go
@@ -35,6 +35,23 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 )
 
+func makeSC(name, tenant, tier string) *storagev1.StorageClass {
+	labels := map[string]string{}
+	if tenant != "" {
+		labels[osacTenantAnnotation] = tenant
+	}
+	if tier != "" {
+		labels[osacStorageTierLabel] = tier
+	}
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Provisioner: "kubernetes.io/no-provisioner",
+	}
+}
+
 var _ = Describe("Tenant Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
@@ -71,7 +88,7 @@ var _ = Describe("Tenant Controller", func() {
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
 
-		It("should transition through all Ready/Progressing phases with conditions", func() {
+		It("should transition through all Ready/Progressing phases with multi-tier StorageClasses", func() {
 			fakeRecorder := events.NewFakeRecorder(100)
 			controllerReconciler := NewTenantReconciler(testMcManager, "default", mcmanager.LocalCluster)
 			controllerReconciler.Recorder = fakeRecorder
@@ -87,15 +104,10 @@ var _ = Describe("Tenant Controller", func() {
 				}})
 				return err
 			}
-			// reconcileAndAssertStatus re-reconciles on each retry so that
-			// the controller's informer cache has time to observe recent
-			// creates / deletes before the assertions are evaluated.
-			// The reconcile error is intentionally ignored because the
-			// reconciler may return transient errors (e.g. namespace not
-			// found) while still correctly setting status conditions.
-			reconcileAndAssertStatus := func(
+
+			reconcileAndAssertPhase := func(
 				expectedPhase v1alpha1.TenantPhaseType,
-				expectedSC string,
+				expectedSCs []v1alpha1.ResolvedStorageClass,
 				expectedNSStatus metav1.ConditionStatus,
 				expectedNSReason string,
 				expectedSCStatus metav1.ConditionStatus,
@@ -105,13 +117,10 @@ var _ = Describe("Tenant Controller", func() {
 					_ = doReconcile()
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, tenant)).To(Succeed())
 					g.Expect(tenant.Status.Phase).To(Equal(expectedPhase))
-					g.Expect(tenant.Status.StorageClass).To(Equal(expectedSC))
-					if expectedSC == "" {
+					if expectedSCs == nil {
 						g.Expect(tenant.Status.StorageClasses).To(BeNil())
 					} else {
-						g.Expect(tenant.Status.StorageClasses).To(HaveLen(1))
-						g.Expect(tenant.Status.StorageClasses[0].Name).To(Equal(expectedSC))
-						g.Expect(tenant.Status.StorageClasses[0].Tier).To(Equal("default"))
+						g.Expect(tenant.Status.StorageClasses).To(ConsistOf(expectedSCs))
 					}
 
 					nsCond := tenant.GetStatusCondition(v1alpha1.TenantConditionNamespaceReady)
@@ -125,6 +134,7 @@ var _ = Describe("Tenant Controller", func() {
 					g.Expect(scCond.Reason).To(Equal(expectedSCReason))
 				}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 			}
+
 			assertSCConditionMessage := func(substrings ...string) {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, tenant)).To(Succeed())
@@ -136,15 +146,15 @@ var _ = Describe("Tenant Controller", func() {
 				}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 			}
 
-			// ── Step 1: no namespace → Progressing, NamespaceReady=False ──────────
+			// ── Step 1: no namespace → Progressing ──────────────────────────
 			By("reconciling when namespace does not exist")
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseProgressing, "",
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseProgressing, nil,
 				metav1.ConditionFalse, v1alpha1.TenantReasonNotFound,
 				metav1.ConditionFalse, v1alpha1.TenantReasonNotFound,
 			)
 
-			// ── Step 2: namespace exists, no SC → Progressing, SC NotFound ────────
+			// ── Step 2: namespace exists, no SCs → Progressing, NotFound ────
 			By("creating the namespace")
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
@@ -152,147 +162,174 @@ var _ = Describe("Tenant Controller", func() {
 			Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
 			DeferCleanup(func() { _ = k8sClient.Delete(ctx, namespace) })
 
-			By("reconciling with namespace but no StorageClass")
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseProgressing, "",
+			By("reconciling with namespace but no StorageClasses")
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseProgressing, nil,
 				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
 				metav1.ConditionFalse, v1alpha1.TenantReasonNotFound,
 			)
 
-			// ── Step 3: Default SC only → Ready via SharedDefault ─────────────────
-			By("creating a shared Default StorageClass")
-			defaultSC := &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "shared-default-sc",
-					Labels: map[string]string{osacTenantAnnotation: defaultStorageClassSentinel},
-				},
-				Provisioner: "kubernetes.io/no-provisioner",
-			}
+			// ── Step 3: SC without storage-tier label → ignored ─────────────
+			By("creating a StorageClass without storage-tier label (should be ignored)")
+			scNoTier := makeSC("sc-no-tier", resourceName, "")
+			Expect(k8sClient.Create(ctx, scNoTier)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, scNoTier) })
+
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseProgressing, nil,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+				metav1.ConditionFalse, v1alpha1.TenantReasonNotFound,
+			)
+
+			// ── Step 4: shared Default SC with tier → Ready via fallback ─────
+			By("creating a shared Default StorageClass with tier label")
+			defaultSC := makeSC("shared-default-sc", defaultStorageClassSentinel, "default")
 			Expect(k8sClient.Create(ctx, defaultSC)).To(Succeed())
 			DeferCleanup(func() { _ = k8sClient.Delete(ctx, defaultSC) })
 
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseReady, "shared-default-sc",
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseReady,
+				[]v1alpha1.ResolvedStorageClass{
+					{Name: "shared-default-sc", Tier: "default"},
+				},
 				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
-				metav1.ConditionTrue, v1alpha1.TenantReasonSharedDefault,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
 			)
 
-			// ── Step 4: tenant SC added → Ready via Found (priority over Default) ─
-			By("creating a tenant-specific StorageClass")
-			tenantSC := &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   resourceName + "-sc",
-					Labels: map[string]string{osacTenantAnnotation: resourceName},
-				},
-				Provisioner: "kubernetes.io/no-provisioner",
-			}
+			// ── Step 5: tenant-specific SC takes priority over Default ───────
+			By("creating a tenant-specific StorageClass for the same tier")
+			tenantSC := makeSC(resourceName+"-default-sc", resourceName, "default")
 			Expect(k8sClient.Create(ctx, tenantSC)).To(Succeed())
 			DeferCleanup(func() { _ = k8sClient.Delete(ctx, tenantSC) })
 
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseReady, resourceName+"-sc",
-				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
-				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
-			)
-
-			// ── Step 5: multiple tenant SCs → Progressing, MultipleFound ──────────
-			By("creating a second tenant StorageClass (misconfiguration)")
-			extraSC := &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   resourceName + "-sc-extra",
-					Labels: map[string]string{osacTenantAnnotation: resourceName},
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseReady,
+				[]v1alpha1.ResolvedStorageClass{
+					{Name: resourceName + "-default-sc", Tier: "default"},
 				},
-				Provisioner: "kubernetes.io/no-provisioner",
-			}
-			Expect(k8sClient.Create(ctx, extraSC)).To(Succeed())
-			DeferCleanup(func() { _ = k8sClient.Delete(ctx, extraSC) })
-
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseProgressing, "",
 				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
-				metav1.ConditionFalse, v1alpha1.TenantReasonMultipleFound,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
 			)
-			By("verifying condition message names the conflicting StorageClasses")
-			assertSCConditionMessage(resourceName+"-sc", resourceName+"-sc-extra")
+			assertSCConditionMessage("tenant-specific")
+
+			// ── Step 6: add a second tier → two resolved entries ─────────────
+			By("adding a fast tier StorageClass for the tenant")
+			tenantFastSC := makeSC(resourceName+"-fast-sc", resourceName, "fast")
+			Expect(k8sClient.Create(ctx, tenantFastSC)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, tenantFastSC) })
+
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseReady,
+				[]v1alpha1.ResolvedStorageClass{
+					{Name: resourceName + "-default-sc", Tier: "default"},
+					{Name: resourceName + "-fast-sc", Tier: "fast"},
+				},
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+			)
+
+			// ── Step 7: duplicate within one tier does not affect the other ──
+			By("creating a duplicate fast tier StorageClass")
+			extraFastSC := makeSC(resourceName+"-fast-sc-extra", resourceName, "fast")
+			Expect(k8sClient.Create(ctx, extraFastSC)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, extraFastSC) })
+
+			By("verifying tenant is still Ready (default tier resolves, fast tier has error)")
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseReady,
+				[]v1alpha1.ResolvedStorageClass{
+					{Name: resourceName + "-default-sc", Tier: "default"},
+				},
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+			)
+			assertSCConditionMessage("fast", "multiple")
 
 			By("verifying a DuplicateStorageClass warning event was emitted")
-			// The Eventually loop in reconcileAndAssertStatus may reconcile multiple times before the
-			// informer cache observes the new SC, and each reconcile that sees duplicates emits an
-			// event. Use Eventually here so the assertion tolerates extra queued events.
 			Eventually(fakeRecorder.Events).Should(Receive(And(
 				ContainSubstring("Warning"),
 				ContainSubstring(eventReasonDuplicateStorageClass),
-				ContainSubstring(resourceName+"-sc"),
-				ContainSubstring(resourceName+"-sc-extra"),
+				ContainSubstring("fast"),
 			)))
 
-			// ── Step 6: remove extra SC → back to Ready (tenant SC) ───────────────
-			By("removing the extra tenant StorageClass")
-			Expect(k8sClient.Delete(ctx, extraSC)).To(Succeed())
+			// ── Step 8: remove duplicate → both tiers resolve again ──────────
+			By("removing the extra fast StorageClass")
+			Expect(k8sClient.Delete(ctx, extraFastSC)).To(Succeed())
 
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseReady, resourceName+"-sc",
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseReady,
+				[]v1alpha1.ResolvedStorageClass{
+					{Name: resourceName + "-default-sc", Tier: "default"},
+					{Name: resourceName + "-fast-sc", Tier: "fast"},
+				},
 				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
 				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
 			)
 
-			// ── Step 7: remove tenant SC → falls back to Default SC ───────────────
-			By("removing the tenant-specific StorageClass")
+			// ── Step 9: mixed resolution — tenant fast, Default for standard ─
+			By("adding a shared Default standard tier")
+			defaultStandardSC := makeSC("shared-standard-sc", defaultStorageClassSentinel, "standard")
+			Expect(k8sClient.Create(ctx, defaultStandardSC)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, defaultStandardSC) })
+
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseReady,
+				[]v1alpha1.ResolvedStorageClass{
+					{Name: resourceName + "-default-sc", Tier: "default"},
+					{Name: resourceName + "-fast-sc", Tier: "fast"},
+					{Name: "shared-standard-sc", Tier: "standard"},
+				},
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+			)
+
+			// ── Step 10: remove all tenant SCs → falls back to Default per tier
+			By("removing tenant-specific StorageClasses")
 			Expect(k8sClient.Delete(ctx, tenantSC)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, tenantFastSC)).To(Succeed())
 
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseReady, "shared-default-sc",
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseReady,
+				[]v1alpha1.ResolvedStorageClass{
+					{Name: "shared-default-sc", Tier: "default"},
+					{Name: "shared-standard-sc", Tier: "standard"},
+				},
 				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
-				metav1.ConditionTrue, v1alpha1.TenantReasonSharedDefault,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
 			)
 
-			// ── Step 8: remove Default SC → Progressing, NotFound ─────────────────
-			By("removing the shared Default StorageClass")
+			// ── Step 11: remove all SCs → Progressing, NotFound ──────────────
+			By("removing all StorageClasses")
 			Expect(k8sClient.Delete(ctx, defaultSC)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, defaultStandardSC)).To(Succeed())
 
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseProgressing, "",
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseProgressing, nil,
 				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
 				metav1.ConditionFalse, v1alpha1.TenantReasonNotFound,
 			)
 
-			// ── Step 9: multiple Default SCs → Progressing, MultipleDefaultsFound ─
-			By("creating two Default StorageClasses (ambiguous)")
-			defaultSC1 := &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "shared-default-sc-1",
-					Labels: map[string]string{osacTenantAnnotation: defaultStorageClassSentinel},
-				},
-				Provisioner: "kubernetes.io/no-provisioner",
-			}
-			defaultSC2 := &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "shared-default-sc-2",
-					Labels: map[string]string{osacTenantAnnotation: defaultStorageClassSentinel},
-				},
-				Provisioner: "kubernetes.io/no-provisioner",
-			}
-			Expect(k8sClient.Create(ctx, defaultSC1)).To(Succeed())
-			DeferCleanup(func() { _ = k8sClient.Delete(ctx, defaultSC1) })
-			Expect(k8sClient.Create(ctx, defaultSC2)).To(Succeed())
-			DeferCleanup(func() { _ = k8sClient.Delete(ctx, defaultSC2) })
-
-			reconcileAndAssertStatus(
-				v1alpha1.TenantPhaseProgressing, "",
-				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
-				metav1.ConditionFalse, v1alpha1.TenantReasonMultipleDefaultsFound,
-			)
-			By("verifying condition message names the conflicting Default StorageClasses and affected tenant")
-			assertSCConditionMessage("shared-default-sc-1", "shared-default-sc-2", resourceName)
-
-			By("verifying a DuplicateStorageClass warning event was emitted for Default SCs")
+			By("verifying a StorageClassNotReady warning event was emitted")
 			Eventually(fakeRecorder.Events).Should(Receive(And(
 				ContainSubstring("Warning"),
-				ContainSubstring(eventReasonDuplicateStorageClass),
-				ContainSubstring("shared-default-sc-1"),
-				ContainSubstring("shared-default-sc-2"),
-				ContainSubstring(resourceName),
+				ContainSubstring(eventReasonStorageClassNotReady),
 			)))
+
+			// ── Step 12: all tiers have duplicates → Progressing, MultipleFound
+			By("creating two Default SCs for the same tier (both duplicate)")
+			dupSC1 := makeSC("dup-default-1", defaultStorageClassSentinel, "default")
+			dupSC2 := makeSC("dup-default-2", defaultStorageClassSentinel, "default")
+			Expect(k8sClient.Create(ctx, dupSC1)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, dupSC1) })
+			Expect(k8sClient.Create(ctx, dupSC2)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, dupSC2) })
+
+			reconcileAndAssertPhase(
+				v1alpha1.TenantPhaseProgressing, nil,
+				metav1.ConditionTrue, v1alpha1.TenantReasonFound,
+				metav1.ConditionFalse, v1alpha1.TenantReasonMultipleFound,
+			)
+			assertSCConditionMessage("dup-default-1", "dup-default-2")
 		})
 	})
 })
@@ -323,5 +360,45 @@ var _ = Describe("joinStorageClassNames", func() {
 		})
 		Expect(joined).To(Equal("sc-a, sc-b"))
 		Expect(names).To(Equal([]string{"sc-a", "sc-b"}))
+	})
+})
+
+var _ = Describe("groupByTier", func() {
+	It("ignores StorageClasses without storage-tier label", func() {
+		scs := []storagev1.StorageClass{
+			*makeSC("sc-no-tier", "tenant-a", ""),
+			*makeSC("sc-with-tier", "tenant-a", "fast"),
+		}
+		groups := groupByTier(scs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups).To(HaveKey("fast"))
+		Expect(groups["fast"]).To(HaveLen(1))
+	})
+
+	It("groups multiple SCs by tier", func() {
+		scs := []storagev1.StorageClass{
+			*makeSC("sc-fast-1", "tenant-a", "fast"),
+			*makeSC("sc-fast-2", "tenant-a", "fast"),
+			*makeSC("sc-standard", "tenant-a", "standard"),
+		}
+		groups := groupByTier(scs)
+		Expect(groups).To(HaveLen(2))
+		Expect(groups["fast"]).To(HaveLen(2))
+		Expect(groups["standard"]).To(HaveLen(1))
+	})
+
+	It("returns empty map for empty input", func() {
+		groups := groupByTier(nil)
+		Expect(groups).To(BeEmpty())
+	})
+
+	It("normalizes tier values to lowercase", func() {
+		scs := []storagev1.StorageClass{
+			*makeSC("sc-upper", "tenant-a", "FAST"),
+			*makeSC("sc-lower", "tenant-a", "fast"),
+		}
+		groups := groupByTier(scs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups["fast"]).To(HaveLen(2))
 	})
 })

--- a/internal/controller/tenant_controller_test.go
+++ b/internal/controller/tenant_controller_test.go
@@ -403,4 +403,16 @@ var _ = Describe("groupByTier", func() {
 		Expect(groups).To(HaveLen(1))
 		Expect(groups["fast"]).To(HaveLen(2))
 	})
+
+	It("ignores tier values that don't match CRD pattern after lowercasing", func() {
+		scs := []storagev1.StorageClass{
+			*makeSC("sc-valid", "tenant-a", "fast"),
+			*makeSC("sc-invalid-chars", "tenant-a", "not valid!"),
+			*makeSC("sc-invalid-start", "tenant-a", "-leading-dash"),
+			*makeSC("sc-invalid-end", "tenant-a", "trailing-dash-"),
+		}
+		groups := groupByTier(scs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups).To(HaveKey("fast"))
+	})
 })

--- a/internal/controller/tenant_names.go
+++ b/internal/controller/tenant_names.go
@@ -35,6 +35,9 @@ const (
 
 	// eventActionDetectDuplicate is the event action for duplicate StorageClass detection
 	eventActionDetectDuplicate = "DetectDuplicate"
+
+	// eventReasonStorageClassNotReady is the event reason emitted when no storage tier resolves
+	eventReasonStorageClassNotReady = "StorageClassNotReady"
 )
 
 var (


### PR DESCRIPTION
## Summary

- Replace single-tier `getTenantStorageClass()` with `getTenantStorageClasses()` that resolves all storage tiers independently
- For each distinct `storage-tier` label value, apply two-step fallback: tenant-specific SC first, then shared Default SC
- StorageClasses without the `osac.openshift.io/storage-tier` label are ignored
- Tier values normalized to lowercase
- Tenant is `Ready` when at least one tier resolves; `Progressing` when none do
- Per-tier duplicate detection emits `DuplicateStorageClass` warning events without blocking other tiers
- Emit `StorageClassNotReady` warning event when no tier resolves
- Adds `groupByTier()` helper that classifies StorageClasses by tier label
- Deprecated `status.storageClass` field populated from the first resolved tier for backward compatibility ([MGMT-24139](https://redhat.atlassian.net/browse/MGMT-24139))

Implements the resolution algorithm from EP [#32](https://github.com/osac-project/enhancement-proposals/pull/32).

## Test plan

- [x] `make test` passes — 12-step integration test covering: no namespace, no SCs, SC without tier label ignored, shared Default fallback, tenant-specific priority, multi-tier resolution, per-tier duplicate isolation, mixed resolution, full degradation with NotReady event, all-tiers-duplicate
- [x] Unit tests for `groupByTier()` (including lowercase normalization) and `joinStorageClassNames()`
- [x] `go build ./...` compiles cleanly

Jira: [MGMT-23977](https://redhat.atlassian.net/browse/MGMT-23977)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage is resolved per storage-tier; tenant status lists all resolved storage classes by tier and still marks a primary choice.
  * Emits warning events when tiers are unresolvable; new distinct event reason for "not ready" cases.

* **Chores**
  * Simplified tenant condition reasons (removed redundant constants).

* **Tests**
  * Expanded coverage for multi-tier resolution, grouping/normalization, per-tier priority/fallback, and duplicate/misconfiguration cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->