### PR TITLE
MGMT-23735/MGMT-23905,MGMT-23906: add PublicIP operator controller and registration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -429,8 +429,8 @@ func setupTenantController(mgr mcmanager.Manager) error {
 	return nil
 }
 
-// setupNetworkingControllers registers the VirtualNetwork, Subnet, SecurityGroup, and PublicIPPool controllers
-// along with their feedback controllers when grpcConn is set.
+// setupNetworkingControllers registers the VirtualNetwork, Subnet, SecurityGroup, PublicIPPool,
+// and PublicIP controllers along with their feedback controllers when grpcConn is set.
 func setupNetworkingControllers(
 	mgr mcmanager.Manager,
 	grpcConn *grpc.ClientConn,
@@ -522,6 +522,14 @@ func setupNetworkingControllers(
 		maxJobHistory, targetCluster,
 	).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("publicippool controller: %w", err)
+	}
+
+	// Setup PublicIP controller
+	// Feedback controller is tracked separately in MGMT-23908.
+	if err := controller.NewPublicIPReconciler(mgr, networkingNamespace, networkingProvider, statusPollInterval,
+		maxJobHistory, targetCluster,
+	).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("publicip controller: %w", err)
 	}
 
 	return nil

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,6 +61,7 @@ rules:
   - clusterorders
   - computeinstances
   - publicippools
+  - publicips
   - securitygroups
   - subnets
   - tenants
@@ -79,6 +80,7 @@ rules:
   - clusterorders/finalizers
   - computeinstances/finalizers
   - publicippools/finalizers
+  - publicips/finalizers
   - securitygroups/finalizers
   - subnets/finalizers
   - tenants/finalizers
@@ -91,6 +93,7 @@ rules:
   - clusterorders/status
   - computeinstances/status
   - publicippools/status
+  - publicips/status
   - securitygroups/status
   - subnets/status
   - tenants/status

--- a/internal/controller/constants_common.go
+++ b/internal/controller/constants_common.go
@@ -33,4 +33,8 @@ const (
 	// This is derived from the NetworkClass and used by AAP playbooks to select the appropriate role
 	// (e.g., "cudn" -> cudn_virtual_network or cudn_subnet role).
 	osacImplementationStrategyAnnotation = osacPrefix + "/implementation-strategy"
+
+	// defaultPublicIPPoolImplementationStrategy is the fallback strategy when none is specified.
+	// Used by PublicIPPool (from its own spec) and PublicIP (inherited from parent pool).
+	defaultPublicIPPoolImplementationStrategy = "metallb-l2"
 )

--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -1,0 +1,380 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mc "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	"github.com/osac-project/osac-operator/api/v1alpha1"
+	"github.com/osac-project/osac-operator/internal/provisioning"
+)
+
+const (
+	osacPublicIPFinalizer = "osac.openshift.io/publicip-finalizer"
+)
+
+// PublicIPReconciler reconciles PublicIP CRs created by the fulfillment-service.
+//
+// Each PublicIP belongs to a parent PublicIPPool (referenced by UUID in spec.pool).
+// The controller adds a finalizer, inherits the implementation strategy from the
+// parent pool, then delegates to the shared provisioning lifecycle to trigger AAP
+// jobs for provisioning and deprovisioning.
+//
+// Phase transitions: "" -> Progressing -> Ready/Failed; on delete: Deleting.
+type PublicIPReconciler struct {
+	client.Client
+	APIReader            client.Reader
+	Scheme               *runtime.Scheme
+	mgr                  mcmanager.Manager
+	NetworkingNamespace  string
+	ProvisioningProvider provisioning.ProvisioningProvider
+	StatusPollInterval   time.Duration
+	MaxJobHistory        int
+	targetCluster        mc.ClusterName
+}
+
+// NewPublicIPReconciler creates a new reconciler for PublicIP resources.
+func NewPublicIPReconciler(
+	mgr mcmanager.Manager,
+	networkingNamespace string,
+	provisioningProvider provisioning.ProvisioningProvider,
+	statusPollInterval time.Duration,
+	maxJobHistory int,
+	targetCluster mc.ClusterName,
+) *PublicIPReconciler {
+	if mgr == nil {
+		panic("mgr must not be nil")
+	}
+	if statusPollInterval <= 0 {
+		statusPollInterval = provisioning.DefaultStatusPollInterval
+	}
+	if maxJobHistory <= 0 {
+		maxJobHistory = provisioning.DefaultMaxJobHistory
+	}
+	return &PublicIPReconciler{
+		Client:               mgr.GetLocalManager().GetClient(),
+		APIReader:            mgr.GetLocalManager().GetAPIReader(),
+		Scheme:               mgr.GetLocalManager().GetScheme(),
+		mgr:                  mgr,
+		NetworkingNamespace:  networkingNamespace,
+		ProvisioningProvider: provisioningProvider,
+		StatusPollInterval:   statusPollInterval,
+		MaxJobHistory:        maxJobHistory,
+		targetCluster:        targetCluster,
+	}
+}
+
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicips,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicips/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicips/finalizers,verbs=update
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicippools,verbs=get;list;watch
+
+// Reconcile handles create/update/delete for a PublicIP CR.
+// On create/update it ensures a finalizer, resolves the parent pool, and runs provisioning.
+// On delete it triggers deprovisioning and removes the finalizer when complete.
+func (r *PublicIPReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	publicIP := &v1alpha1.PublicIP{}
+	err := r.Get(ctx, req.NamespacedName, publicIP)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Skip unmanaged resources, but still allow deletion to proceed
+	val, exists := publicIP.Annotations[osacManagementStateAnnotation]
+	if publicIP.ObjectMeta.DeletionTimestamp.IsZero() && exists && val == ManagementStateUnmanaged {
+		log.Info("ignoring PublicIP due to management-state annotation", "management-state", val)
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("start reconcile", "pool", publicIP.Spec.Pool, "phase", publicIP.Status.Phase)
+
+	oldstatus := publicIP.Status.DeepCopy()
+
+	var res ctrl.Result
+	if publicIP.ObjectMeta.DeletionTimestamp.IsZero() {
+		res, err = r.handleUpdate(ctx, publicIP)
+	} else {
+		res, err = r.handleDelete(ctx, publicIP)
+	}
+
+	if !equality.Semantic.DeepEqual(publicIP.Status, *oldstatus) {
+		log.Info("status requires update", "phase", publicIP.Status.Phase)
+		if updateErr := r.Status().Update(ctx, publicIP); updateErr != nil {
+			log.Error(updateErr, "failed to update status")
+			return res, updateErr
+		}
+	}
+
+	log.Info("end reconcile", "phase", publicIP.Status.Phase)
+	return res, err
+}
+
+// handleUpdate processes a non-deleted PublicIP: adds finalizer, resolves the parent
+// PublicIPPool, inherits the implementation strategy, and runs provisioning.
+func (r *PublicIPReconciler) handleUpdate(ctx context.Context, publicIP *v1alpha1.PublicIP) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	// Add finalizer if not present
+	if controllerutil.AddFinalizer(publicIP, osacPublicIPFinalizer) {
+		log.Info("adding finalizer")
+		if err := r.Update(ctx, publicIP); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Re-fetch to get the latest resourceVersion after the metadata update
+		if err := r.Get(ctx, client.ObjectKeyFromObject(publicIP), publicIP); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if publicIP.Status.Phase == "" {
+		publicIP.Status.Phase = v1alpha1.PublicIPPhaseProgressing
+	}
+
+	// Resolve the parent PublicIPPool by the fulfillment-service UUID stored in spec.pool.
+	// The fulfillment-service creates pool CRs with a UUID label; spec.pool contains that
+	// UUID, not the K8s object name.
+	poolList := &v1alpha1.PublicIPPoolList{}
+	err := r.List(ctx, poolList,
+		client.InNamespace(publicIP.Namespace),
+		client.MatchingLabels{osacPublicIPPoolIDLabel: publicIP.Spec.Pool},
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(poolList.Items) == 0 {
+		log.Info("parent PublicIPPool not found, requeueing", "poolUUID", publicIP.Spec.Pool)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+	pool := &poolList.Items[0]
+	log.Info("resolved parent PublicIPPool", "poolName", pool.Name, "poolUUID", publicIP.Spec.Pool)
+
+	// Inherit implementation strategy from the parent pool. Unlike PublicIPPool (which
+	// reads strategy from its own spec), PublicIP must look it up from the parent.
+	implementationStrategy := pool.Spec.ImplementationStrategy
+	if implementationStrategy == "" {
+		implementationStrategy = defaultPublicIPPoolImplementationStrategy
+	}
+
+	// Annotate the CR so AAP playbooks can select the appropriate role without
+	// having to look up the parent pool themselves.
+	if publicIP.Annotations == nil {
+		publicIP.Annotations = make(map[string]string)
+	}
+	if publicIP.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
+		publicIP.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
+		log.Info("setting implementation-strategy annotation", "strategy", implementationStrategy)
+		if err := r.Update(ctx, publicIP); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Re-fetch to get the latest resourceVersion after the metadata update
+		if err := r.Get(ctx, client.ObjectKeyFromObject(publicIP), publicIP); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Compute desired config version from spec and inherited implementation strategy.
+	// This hash drives the provisioning lifecycle: a new version triggers re-provisioning.
+	desiredVersion, err := provisioning.ComputeDesiredConfigVersion(struct {
+		Spec                   v1alpha1.PublicIPSpec
+		ImplementationStrategy string
+	}{publicIP.Spec, implementationStrategy})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to compute desired config version: %w", err)
+	}
+	publicIP.Status.DesiredConfigVersion = desiredVersion
+
+	v1alpha1.SetPublicIPStatusCondition(publicIP, metav1.Condition{
+		Type:               string(v1alpha1.PublicIPConditionConfigurationApplied),
+		Status:             metav1.ConditionTrue,
+		Reason:             "ConfigurationApplied",
+		Message:            "Controller has processed the current spec",
+		LastTransitionTime: metav1.Now(),
+	})
+
+	// Transition to Progressing on first provision or when spec changed after a previous
+	// success. Don't override Failed during backoff (the provisioning lifecycle handles retry).
+	if publicIP.Status.Phase == "" || (publicIP.Status.Phase == v1alpha1.PublicIPPhaseReady &&
+		!provisioning.IsConfigApplied(&publicIP.Status.Jobs, publicIP.Status.DesiredConfigVersion)) {
+		publicIP.Status.Phase = v1alpha1.PublicIPPhaseProgressing
+	}
+
+	return r.handleProvisioning(ctx, publicIP)
+}
+
+// handleDelete sets the Deleting phase, runs deprovisioning, and removes the finalizer
+// once deprovisioning completes (or is skipped).
+func (r *PublicIPReconciler) handleDelete(ctx context.Context, publicIP *v1alpha1.PublicIP) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+	log.Info("deleting public IP")
+
+	publicIP.Status.Phase = v1alpha1.PublicIPPhaseDeleting
+
+	if !controllerutil.ContainsFinalizer(publicIP, osacPublicIPFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	result, err := r.handleDeprovisioning(ctx, publicIP)
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
+	}
+
+	// Deprovisioning complete, remove finalizer to allow K8s garbage collection
+	log.Info("removing finalizer after successful deprovisioning")
+	controllerutil.RemoveFinalizer(publicIP, osacPublicIPFinalizer)
+	if err := r.Update(ctx, publicIP); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// handleProvisioning delegates to the shared provisioning lifecycle, which triggers
+// an AAP job (e.g., osac-create-public-ip) and polls its status until completion.
+func (r *PublicIPReconciler) handleProvisioning(ctx context.Context, publicIP *v1alpha1.PublicIP) (ctrl.Result, error) {
+	if r.ProvisioningProvider == nil {
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping provisioning")
+		return ctrl.Result{}, nil
+	}
+
+	return provisioning.RunProvisioningLifecycle(ctx, r.ProvisioningProvider, publicIP,
+		&provisioning.State{Jobs: &publicIP.Status.Jobs, DesiredConfigVersion: publicIP.Status.DesiredConfigVersion},
+		r.MaxJobHistory, r.StatusPollInterval,
+		&provisioning.PollCallbacks{
+			OnFailed:  func(_ string) { publicIP.Status.Phase = v1alpha1.PublicIPPhaseFailed },
+			OnSuccess: func(_ provisioning.ProvisionStatus) { publicIP.Status.Phase = v1alpha1.PublicIPPhaseReady },
+		},
+		func() bool {
+			return provisioning.CheckAPIServerForNonTerminalProvisionJob(
+				ctx, r.APIReader, client.ObjectKeyFromObject(publicIP), &v1alpha1.PublicIP{})
+		},
+		func() error { return r.Status().Update(ctx, publicIP) },
+	)
+}
+
+// handleDeprovisioning triggers an AAP deprovisioning job (e.g., osac-delete-public-ip)
+// and polls its status. On failure, it either blocks deletion (to prevent orphaned
+// resources) or allows the process to continue, depending on provider policy.
+func (r *PublicIPReconciler) handleDeprovisioning(ctx context.Context, publicIP *v1alpha1.PublicIP) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	if r.ProvisioningProvider == nil {
+		log.Info("no provisioning provider configured, skipping deprovisioning")
+		return ctrl.Result{}, nil
+	}
+
+	latestDeprovisionJob := provisioning.FindLatestJobByType(publicIP.Status.Jobs, v1alpha1.JobTypeDeprovision)
+
+	// Trigger a new deprovisioning job if none exists yet
+	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
+		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
+
+		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, publicIP)
+		if err != nil {
+			log.Error(err, "failed to trigger deprovisioning")
+			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+		}
+
+		switch result.Action {
+		case provisioning.DeprovisionWaiting:
+			log.Info("deprovisioning not ready, requeueing")
+			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+
+		case provisioning.DeprovisionSkipped:
+			log.Info("provider skipped deprovisioning")
+			return ctrl.Result{}, nil
+
+		case provisioning.DeprovisionTriggered:
+			newJob := v1alpha1.JobStatus{
+				JobID:                  result.JobID,
+				Type:                   v1alpha1.JobTypeDeprovision,
+				Timestamp:              metav1.NewTime(time.Now().UTC()),
+				State:                  v1alpha1.JobStatePending,
+				Message:                "Deprovisioning job triggered",
+				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
+			}
+			publicIP.Status.Jobs = provisioning.AppendJob(publicIP.Status.Jobs, newJob, r.MaxJobHistory)
+			log.Info("deprovisioning job triggered", "jobID", result.JobID)
+			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+		}
+	}
+
+	// Poll the existing deprovisioning job
+	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, publicIP, latestDeprovisionJob.JobID)
+	if err != nil {
+		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
+		updatedJob := *latestDeprovisionJob
+		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
+		provisioning.UpdateJob(publicIP.Status.Jobs, updatedJob)
+		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	updatedJob := *latestDeprovisionJob
+	updatedJob.State = status.State
+	updatedJob.Message = status.MessageWithDetails()
+	provisioning.UpdateJob(publicIP.Status.Jobs, updatedJob)
+
+	if !status.State.IsTerminal() {
+		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
+		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	if status.State.IsSuccessful() {
+		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
+		return ctrl.Result{}, nil
+	}
+
+	if latestDeprovisionJob.BlockDeletionOnFailure {
+		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
+			"jobID", latestDeprovisionJob.JobID,
+			"state", status.State,
+			"message", updatedJob.Message)
+		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	log.Info("deprovision job did not succeed, allowing process to continue",
+		"jobID", latestDeprovisionJob.JobID,
+		"state", status.State,
+		"message", updatedJob.Message)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers this controller with the multicluster manager.
+// It watches PublicIP CRs in the networking namespace on the local cluster only.
+func (r *PublicIPReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	return mcbuilder.ControllerManagedBy(mgr).
+		For(&v1alpha1.PublicIP{},
+			mcbuilder.WithPredicates(NetworkingNamespacePredicate(r.NetworkingNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false)).
+		Complete(r)
+}

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -35,12 +35,14 @@ import (
 	"github.com/osac-project/osac-operator/internal/provisioning"
 )
 
-// Tests for the PublicIPPool provisioning controller.
+// Tests for the PublicIP provisioning controller.
 //
 // Key concepts for understanding these tests:
 //
-//   - Unlike PublicIP (which inherits strategy from its parent pool), PublicIPPool reads
-//     the implementation strategy from its own spec.implementationStrategy field.
+//   - A PublicIP belongs to a parent PublicIPPool. The relationship uses fulfillment-service
+//     UUIDs, not K8s object names: publicIP.spec.pool contains a UUID, and the parent
+//     PublicIPPool CR carries that UUID in its osac.openshift.io/publicippool-uuid label.
+//     The controller resolves the parent by listing pools with a matching label.
 //
 //   - The reconcile loop requires multiple passes because each pass does one thing and
 //     returns: first pass adds the finalizer (metadata write), second pass processes the
@@ -52,14 +54,20 @@ import (
 //   - The mock provisioning provider (defined in computeinstance_provisioning_test.go)
 //     simulates AAP job triggers and status polls. By default it returns success; tests
 //     override specific funcs to simulate failures or running states.
-var _ = Describe("PublicIPPoolReconciler", func() {
+var _ = Describe("PublicIPReconciler", func() {
 	var (
-		reconciler   *PublicIPPoolReconciler
+		reconciler   *PublicIPReconciler
 		mockProvider *mockProvisioningProvider
 		fakeClient   client.Client
 		testCtx      context.Context
-		pool         *osacv1alpha1.PublicIPPool
+		publicIP     *osacv1alpha1.PublicIP
+		parentPool   *osacv1alpha1.PublicIPPool
 		testScheme   *runtime.Scheme
+	)
+
+	const (
+		testNamespace = "test-namespace"
+		testPoolUUID  = "pool-uuid-123"
 	)
 
 	BeforeEach(func() {
@@ -68,10 +76,15 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 		Expect(osacv1alpha1.AddToScheme(testScheme)).To(Succeed())
 		Expect(scheme.AddToScheme(testScheme)).To(Succeed())
 
-		pool = &osacv1alpha1.PublicIPPool{
+		// The parent pool has a K8s name ("pool-k8s-name") that differs from the UUID
+		// ("pool-uuid-123") to verify the controller uses label-based lookup, not name-based.
+		parentPool = &osacv1alpha1.PublicIPPool{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pool",
-				Namespace: "test-namespace",
+				Name:      "pool-k8s-name",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					osacPublicIPPoolIDLabel: testPoolUUID,
+				},
 			},
 			Spec: osacv1alpha1.PublicIPPoolSpec{
 				CIDRs:                  []string{"192.168.1.0/24"},
@@ -80,19 +93,30 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			},
 		}
 
+		// The PublicIP references the parent pool by UUID, not by K8s name.
+		publicIP = &osacv1alpha1.PublicIP{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-publicip",
+				Namespace: testNamespace,
+			},
+			Spec: osacv1alpha1.PublicIPSpec{
+				Pool: testPoolUUID,
+			},
+		}
+
 		fakeClient = fake.NewClientBuilder().
 			WithScheme(testScheme).
-			WithObjects(pool).
-			WithStatusSubresource(&osacv1alpha1.PublicIPPool{}).
+			WithObjects(publicIP, parentPool).
+			WithStatusSubresource(&osacv1alpha1.PublicIP{}).
 			Build()
 
 		mockProvider = &mockProvisioningProvider{name: "mock-aap"}
 
-		reconciler = &PublicIPPoolReconciler{
+		reconciler = &PublicIPReconciler{
 			Client:               fakeClient,
 			APIReader:            fakeClient,
 			Scheme:               testScheme,
-			NetworkingNamespace:  "test-namespace",
+			NetworkingNamespace:  testNamespace,
 			ProvisioningProvider: mockProvider,
 			StatusPollInterval:   1 * time.Second,
 			MaxJobHistory:        10,
@@ -101,19 +125,18 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 
 	Context("Reconcile", func() {
 		It("should add finalizer on first reconcile", func() {
-			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
-			updated := &osacv1alpha1.PublicIPPool{}
+			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-
-			Expect(updated.Finalizers).To(ContainElement(osacPublicIPPoolFinalizer))
+			Expect(updated.Finalizers).To(ContainElement(osacPublicIPFinalizer))
 		})
 
 		It("should set phase to Progressing initially", func() {
-			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 
 			// Keep the job in Running state so the phase stays Progressing
 			// (a Succeeded job would transition to Ready)
@@ -131,17 +154,104 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Pass 2: reads strategy from spec, triggers provisioning, sets Progressing
+			// Pass 2: resolves parent pool, triggers provisioning, sets Progressing
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			updated := &osacv1alpha1.PublicIPPool{}
+			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPPoolPhaseProgressing))
+			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPPhaseProgressing))
+		})
+
+		It("should set implementation-strategy annotation from parent pool", func() {
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
+
+			// Pass 1: adds finalizer
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Pass 2: resolves parent pool and copies its implementation strategy
+			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+		})
+
+		It("should requeue when parent PublicIPPool is not found", func() {
+			// This PublicIP references a pool UUID that doesn't exist as a label
+			// on any PublicIPPool CR. The controller should requeue and wait for
+			// the pool to appear (it may not have been reconciled to K8s yet).
+			orphanIP := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "orphan-publicip",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool: "nonexistent-pool-uuid",
+				},
+			}
+			Expect(fakeClient.Create(testCtx, orphanIP)).To(Succeed())
+
+			key := types.NamespacedName{Name: orphanIP.Name, Namespace: orphanIP.Namespace}
+
+			// Pass 1: adds finalizer
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Pass 2: parent pool not found, requeues after precondition interval
+			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+
+		It("should use default implementation strategy when pool has none", func() {
+			// A pool with no ImplementationStrategy in its spec should fall back
+			// to defaultPublicIPPoolImplementationStrategy ("metallb-l2").
+			poolNoStrategy := &osacv1alpha1.PublicIPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pool-no-strategy",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						osacPublicIPPoolIDLabel: "pool-no-strategy-uuid",
+					},
+				},
+				Spec: osacv1alpha1.PublicIPPoolSpec{
+					CIDRs:    []string{"10.0.0.0/24"},
+					IPFamily: "IPv4",
+				},
+			}
+			Expect(fakeClient.Create(testCtx, poolNoStrategy)).To(Succeed())
+
+			ipNoStrategy := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-no-strategy",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool: "pool-no-strategy-uuid",
+				},
+			}
+			Expect(fakeClient.Create(testCtx, ipNoStrategy)).To(Succeed())
+
+			key := types.NamespacedName{Name: ipNoStrategy.Name, Namespace: ipNoStrategy.Namespace}
+
+			// Pass 1: adds finalizer
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Pass 2: inherits default strategy since pool has none
+			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultPublicIPPoolImplementationStrategy))
 		})
 
 		It("should set ConfigurationApplied condition to True", func() {
-			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 
 			// Pass 1: finalizer, Pass 2: process spec and set condition
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
@@ -149,11 +259,11 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			updated := &osacv1alpha1.PublicIPPool{}
+			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
 
-			condition := osacv1alpha1.GetPublicIPPoolStatusCondition(
-				updated, osacv1alpha1.PublicIPPoolConditionConfigurationApplied,
+			condition := osacv1alpha1.GetPublicIPStatusCondition(
+				updated, osacv1alpha1.PublicIPConditionConfigurationApplied,
 			)
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
@@ -161,7 +271,7 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 		})
 
 		It("should set phase to Ready on successful provision", func() {
-			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 
 			mockProvider.triggerProvisionFunc = func(
 				ctx context.Context, resource client.Object,
@@ -191,13 +301,13 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			updated := &osacv1alpha1.PublicIPPool{}
+			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPPoolPhaseReady))
+			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPPhaseReady))
 		})
 
 		It("should set phase to Failed on provision failure", func() {
-			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 
 			mockProvider.triggerProvisionFunc = func(
 				ctx context.Context, resource client.Object,
@@ -228,9 +338,9 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			updated := &osacv1alpha1.PublicIPPool{}
+			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPPoolPhaseFailed))
+			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPPhaseFailed))
 		})
 
 		// Deletion tests call handleDelete directly because the fake client does not
@@ -238,7 +348,7 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 		// normal Reconcile, then set DeletionTimestamp in memory and call handleDelete.
 
 		It("should trigger deprovision on delete", func() {
-			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 
 			deprovisionCalled := false
 			mockProvider.triggerDeprovisionFunc = func(
@@ -257,7 +367,7 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Simulate K8s delete by setting DeletionTimestamp in memory
-			toDelete := &osacv1alpha1.PublicIPPool{}
+			toDelete := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, toDelete)).To(Succeed())
 			now := metav1.Now()
 			toDelete.DeletionTimestamp = &now
@@ -266,6 +376,7 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(deprovisionCalled).To(BeTrue())
+			Expect(toDelete.Status.Phase).To(Equal(osacv1alpha1.PublicIPPhaseDeleting))
 
 			latestJob := provisioning.FindLatestJobByType(toDelete.Status.Jobs, osacv1alpha1.JobTypeDeprovision)
 			Expect(latestJob).NotTo(BeNil())
@@ -273,7 +384,7 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 		})
 
 		It("should remove finalizer after successful deprovision", func() {
-			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 
 			mockProvider.triggerDeprovisionFunc = func(
 				ctx context.Context, resource client.Object,
@@ -295,46 +406,41 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 				}, nil
 			}
 
-			// Add finalizer first
+			// Add finalizer via normal reconcile
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			toDelete := &osacv1alpha1.PublicIPPool{}
+			toDelete := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, toDelete)).To(Succeed())
-
 			now := metav1.Now()
 			toDelete.DeletionTimestamp = &now
 
-			// First handleDelete triggers deprovision job
+			// First call triggers the deprovision job
 			_, err = reconciler.handleDelete(testCtx, toDelete)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Second handleDelete polls status and removes finalizer
+			// Second call polls status (Succeeded) and removes the finalizer
 			_, _ = reconciler.handleDelete(testCtx, toDelete)
 
-			// Verify finalizer was removed from in-memory object
-			Expect(toDelete.Finalizers).NotTo(ContainElement(osacPublicIPPoolFinalizer))
+			Expect(toDelete.Finalizers).NotTo(ContainElement(osacPublicIPFinalizer))
 		})
 
-		It("should still handle delete for unmanaged pool with finalizer", func() {
-			// Edge case: a pool was managed (has finalizer), then an admin marked
+		It("should still handle delete for unmanaged PublicIP with finalizer", func() {
+			// Edge case: a PublicIP was managed (has finalizer), then an admin marked
 			// it unmanaged. The management-state guard in Reconcile skips processing
 			// for non-deleted resources, but deletion must still proceed to clean up
 			// the AAP-provisioned resources and remove the finalizer.
-			managedThenUnmanaged := &osacv1alpha1.PublicIPPool{
+			managedThenUnmanaged := &osacv1alpha1.PublicIP{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "managed-then-unmanaged",
-					Namespace: "test-namespace",
+					Namespace: testNamespace,
 					Annotations: map[string]string{
 						osacManagementStateAnnotation: ManagementStateUnmanaged,
 					},
-					Finalizers: []string{osacPublicIPPoolFinalizer},
+					Finalizers: []string{osacPublicIPFinalizer},
 				},
-				Spec: osacv1alpha1.PublicIPPoolSpec{
-
-					CIDRs:                  []string{"10.0.0.0/24"},
-					IPFamily:               "IPv4",
-					ImplementationStrategy: "metallb-l2",
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool: testPoolUUID,
 				},
 			}
 			Expect(fakeClient.Create(testCtx, managedThenUnmanaged)).To(Succeed())
@@ -351,60 +457,45 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 				}, nil
 			}
 
-			// Fetch from the fake client, then set DeletionTimestamp in memory
-			// and call handleDelete directly (fake client does not support
-			// DeletionTimestamp via Update, so we test the in-memory behavior).
-			fetched := &osacv1alpha1.PublicIPPool{}
+			fetched := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, fetched)).To(Succeed())
-
 			now := metav1.Now()
 			fetched.DeletionTimestamp = &now
 
-			// Verify the Reconcile guard: with DeletionTimestamp set, the
-			// unmanaged annotation must NOT cause an early return.
-			// DeletionTimestamp.IsZero() is false, so the guard is skipped
-			// and we reach the delete branch.
+			// Verify the guard logic: DeletionTimestamp is set, so the unmanaged
+			// annotation is ignored and the delete branch runs.
 			Expect(fetched.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
 
-			// Call handleDelete directly. The DeprovisionSkipped path removes
-			// the finalizer in memory. The subsequent r.Update will fail on
-			// the fake client (DeletionTimestamp is immutable), but the
-			// important assertion is that deprovision ran and the finalizer
-			// was removed from the in-memory object.
 			_, _ = reconciler.handleDelete(testCtx, fetched)
 
 			Expect(deprovisionCalled).To(BeTrue())
-			Expect(fetched.Finalizers).NotTo(ContainElement(osacPublicIPPoolFinalizer))
+			Expect(fetched.Finalizers).NotTo(ContainElement(osacPublicIPFinalizer))
 		})
 
-		It("should ignore pool with management-state unmanaged annotation", func() {
-			// When a pool has the unmanaged annotation and is NOT being deleted,
+		It("should ignore PublicIP with management-state unmanaged annotation", func() {
+			// When a PublicIP has the unmanaged annotation and is NOT being deleted,
 			// the controller should skip it entirely: no finalizer, no phase change.
-			unmanagedPool := &osacv1alpha1.PublicIPPool{
+			unmanagedIP := &osacv1alpha1.PublicIP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "unmanaged-pool",
-					Namespace: "test-namespace",
+					Name:      "unmanaged-ip",
+					Namespace: testNamespace,
 					Annotations: map[string]string{
 						osacManagementStateAnnotation: ManagementStateUnmanaged,
 					},
 				},
-				Spec: osacv1alpha1.PublicIPPoolSpec{
-
-					CIDRs:                  []string{"10.0.0.0/24"},
-					IPFamily:               "IPv4",
-					ImplementationStrategy: "metallb-l2",
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool: testPoolUUID,
 				},
 			}
-			Expect(fakeClient.Create(testCtx, unmanagedPool)).To(Succeed())
+			Expect(fakeClient.Create(testCtx, unmanagedIP)).To(Succeed())
 
-			key := types.NamespacedName{Name: unmanagedPool.Name, Namespace: unmanagedPool.Namespace}
+			key := types.NamespacedName{Name: unmanagedIP.Name, Namespace: unmanagedIP.Namespace}
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			updated := &osacv1alpha1.PublicIPPool{}
+			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
 
-			// Verify no finalizer was added (controller skipped it)
 			Expect(updated.Finalizers).To(BeEmpty())
 			Expect(updated.Status.Phase).To(BeEmpty())
 		})
@@ -416,8 +507,8 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 	// immediately instead of waiting for the backoff to expire.
 	Context("backoff on failure", func() {
 		It("should backoff when latest job failed with matching ConfigVersion", func() {
-			pool.Status.DesiredConfigVersion = testConfigVersion
-			pool.Status.Jobs = []osacv1alpha1.JobStatus{
+			publicIP.Status.DesiredConfigVersion = testConfigVersion
+			publicIP.Status.Jobs = []osacv1alpha1.JobStatus{
 				{
 					JobID:         "failed-job",
 					Type:          osacv1alpha1.JobTypeProvision,
@@ -428,7 +519,7 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 				},
 			}
 
-			result, err := reconciler.handleProvisioning(testCtx, pool)
+			result, err := reconciler.handleProvisioning(testCtx, publicIP)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 			Expect(result.RequeueAfter).To(BeNumerically("<=", provisioning.BackoffMaxDelay))
@@ -444,8 +535,10 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 				}, nil
 			}
 
-			pool.Status.DesiredConfigVersion = testConfigVersionUpdated
-			pool.Status.Jobs = []osacv1alpha1.JobStatus{
+			// The desired version is "version-2" but the failed job was for "version-1",
+			// meaning the spec changed. The controller should retry immediately.
+			publicIP.Status.DesiredConfigVersion = testConfigVersionUpdated
+			publicIP.Status.Jobs = []osacv1alpha1.JobStatus{
 				{
 					JobID:         "failed-job",
 					Type:          osacv1alpha1.JobTypeProvision,
@@ -456,11 +549,11 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 				},
 			}
 
-			result, err := reconciler.handleProvisioning(testCtx, pool)
+			result, err := reconciler.handleProvisioning(testCtx, publicIP)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(1 * time.Second))
 
-			latestJob := provisioning.FindLatestJobByType(pool.Status.Jobs, osacv1alpha1.JobTypeProvision)
+			latestJob := provisioning.FindLatestJobByType(publicIP.Status.Jobs, osacv1alpha1.JobTypeProvision)
 			Expect(latestJob).NotTo(BeNil())
 			Expect(latestJob.JobID).To(Equal("retry-job"))
 		})

--- a/internal/controller/publicip_names.go
+++ b/internal/controller/publicip_names.go
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+)
+
+// Used by the feedback controller (MGMT-23908).
+var (
+	osacPublicIPIDLabel           string = fmt.Sprintf("%s/publicip-uuid", osacPrefix)     //nolint:unused
+	osacPublicIPFeedbackFinalizer string = fmt.Sprintf("%s/publicip-feedback", osacPrefix) //nolint:unused
+)

--- a/internal/controller/publicippool_controller.go
+++ b/internal/controller/publicippool_controller.go
@@ -42,12 +42,19 @@ const (
 	osacPublicIPPoolFinalizer = "osac.openshift.io/publicippool-finalizer"
 )
 
-// PublicIPPoolReconciler reconciles a PublicIPPool object
+// PublicIPPoolReconciler reconciles PublicIPPool CRs created by the fulfillment-service.
+//
+// A PublicIPPool defines a range of public IP addresses (CIDRs) that can be allocated
+// as individual PublicIP resources. Unlike PublicIP (which inherits its strategy from
+// the parent pool), PublicIPPool reads the implementation strategy from its own spec.
+//
+// The controller adds a finalizer, triggers AAP provisioning/deprovisioning jobs via
+// the shared provisioning lifecycle, and transitions phases:
+// "" -> Progressing -> Ready/Failed; on delete: Deleting.
 type PublicIPPoolReconciler struct {
 	client.Client
-	APIReader client.Reader
-	Scheme    *runtime.Scheme
-	// mgr and targetCluster are stored for future multi-cluster target client resolution
+	APIReader            client.Reader
+	Scheme               *runtime.Scheme
 	mgr                  mcmanager.Manager
 	NetworkingNamespace  string
 	ProvisioningProvider provisioning.ProvisioningProvider
@@ -91,8 +98,9 @@ func NewPublicIPPoolReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=publicippools/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=publicippools/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
+// Reconcile handles create/update/delete for a PublicIPPool CR.
+// On create/update it ensures a finalizer, reads the implementation strategy from spec,
+// and runs provisioning. On delete it triggers deprovisioning and removes the finalizer.
 func (r *PublicIPPoolReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
 
@@ -131,6 +139,8 @@ func (r *PublicIPPoolReconciler) Reconcile(ctx context.Context, req mcreconcile.
 	return res, err
 }
 
+// handleUpdate processes a non-deleted PublicIPPool: adds finalizer, reads the
+// implementation strategy from the pool's own spec, and runs provisioning.
 func (r *PublicIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alpha1.PublicIPPool) (ctrl.Result, error) {
 	// Add finalizer if not present
 	if controllerutil.AddFinalizer(pool, osacPublicIPPoolFinalizer) {
@@ -148,10 +158,10 @@ func (r *PublicIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alpha
 		pool.Status.Phase = v1alpha1.PublicIPPoolPhaseProgressing
 	}
 
-	// Read implementation strategy from spec, defaulting to metallb-l2
+	// Read implementation strategy from spec
 	implementationStrategy := pool.Spec.ImplementationStrategy
 	if implementationStrategy == "" {
-		implementationStrategy = "metallb-l2"
+		implementationStrategy = defaultPublicIPPoolImplementationStrategy
 	}
 
 	// Compute desired config version from spec and implementation strategy
@@ -184,6 +194,8 @@ func (r *PublicIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alpha
 	return r.handleProvisioning(ctx, pool)
 }
 
+// handleDelete sets the Deleting phase, runs deprovisioning, and removes the finalizer
+// once deprovisioning completes (or is skipped).
 func (r *PublicIPPoolReconciler) handleDelete(ctx context.Context, pool *v1alpha1.PublicIPPool) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
 	log.Info("deleting public IP pool")
@@ -210,8 +222,8 @@ func (r *PublicIPPoolReconciler) handleDelete(ctx context.Context, pool *v1alpha
 	return ctrl.Result{}, nil
 }
 
-// handleProvisioning manages the provisioning job lifecycle for a PublicIPPool.
-// Uses shared RunProvisioningLifecycle with config-version-based backoff on failure.
+// handleProvisioning delegates to the shared provisioning lifecycle, which triggers
+// an AAP job (e.g., osac-create-public-ip-pool) and polls its status until completion.
 func (r *PublicIPPoolReconciler) handleProvisioning(ctx context.Context, pool *v1alpha1.PublicIPPool) (ctrl.Result, error) {
 	if r.ProvisioningProvider == nil {
 		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping provisioning")
@@ -233,8 +245,9 @@ func (r *PublicIPPoolReconciler) handleProvisioning(ctx context.Context, pool *v
 	)
 }
 
-// handleDeprovisioning manages the deprovisioning job lifecycle for a PublicIPPool.
-// It triggers deprovisioning if needed and polls job status until completion.
+// handleDeprovisioning triggers an AAP deprovisioning job (e.g., osac-delete-public-ip-pool)
+// and polls its status. On failure, it either blocks deletion (to prevent orphaned
+// resources) or allows the process to continue, depending on provider policy.
 func (r *PublicIPPoolReconciler) handleDeprovisioning(ctx context.Context, pool *v1alpha1.PublicIPPool) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
 
@@ -326,7 +339,8 @@ func (r *PublicIPPoolReconciler) handleDeprovisioning(ctx context.Context, pool 
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
+// SetupWithManager registers this controller with the multicluster manager.
+// It watches PublicIPPool CRs in the networking namespace on the local cluster only.
 func (r *PublicIPPoolReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	return mcbuilder.ControllerManagedBy(mgr).
 		For(&v1alpha1.PublicIPPool{},


### PR DESCRIPTION
## Summary

[MGMT-23905](https://redhat.atlassian.net/browse/MGMT-23905), [MGMT-23906](https://redhat.atlassian.net/browse/MGMT-23906):
Implement the PublicIP provisioning controller in osac-operator
and register it in `setupNetworkingControllers()`.

The controller manages the PublicIP CR lifecycle: adds a finalizer, resolves the parent
PublicIPPool by UUID label to inherit the implementation strategy, computes a desired
config version, and delegates to the shared provisioning lifecycle for AAP job management
(`osac-create-public-ip` / `osac-delete-public-ip`).

Also extracts the hardcoded `"metallb-l2"` default into a shared
`defaultPublicIPPoolImplementationStrategy` constant used by both PublicIPPool and PublicIP
controllers, and adds documentation comments to the PublicIPPool controller and tests.

The feedback controller is tracked separately in
[MGMT-23908](https://redhat.atlassian.net/browse/MGMT-23908).

## Testing

```
$ make test
ok  github.com/osac-project/osac-operator/internal/controller  11.504s  coverage: 61.0%
```

New PublicIP tests (13 specs): finalizer addition, parent pool lookup (found, not found,
no strategy), implementation strategy inheritance, ConfigurationApplied condition, phase
transitions (Progressing, Ready, Failed, Deleting), deprovisioning with finalizer removal,
management-state unmanaged handling, config-version-based backoff.

All existing tests remain green.

## Related PRs

- https://github.com/osac-project/fulfillment-service/pull/441 (PublicIP reconciler, migration, OPA policy)

## Ticket

[MGMT-23905](https://redhat.atlassian.net/browse/MGMT-23905),
[MGMT-23906](https://redhat.atlassian.net/browse/MGMT-23906)
(subtasks of [MGMT-23735](https://redhat.atlassian.net/browse/MGMT-23735))

<br>

<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PublicIP resource controller enabling provisioning, lifecycle management, and status tracking across multicluster environments.
  * Extended RBAC permissions to support PublicIP resource operations.
  * Implemented automatic configuration strategy inheritance from parent PublicIPPool with fallback defaults.

* **Tests**
  * Comprehensive test coverage for PublicIP reconciliation, provisioning workflows, and deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->