### PR TITLE
NO-ISSUE: Add validation refinements to ClusterOrder CRD

### DIFF
--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -55,7 +55,7 @@ type ClusterOrderSpec struct {
 	// If not provided, the template's default release image is used.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxLength=512
-	// +kubebuilder:validation:Pattern=`.+/.+:.+`
+	// +kubebuilder:validation:Pattern=`^.+/.+:.+$`
 	ReleaseImage string `json:"releaseImage,omitempty"`
 	// Network contains cluster networking configuration.
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -44,14 +44,18 @@ type ClusterOrderSpec struct {
 	// PullSecret contains credentials for authenticating to container image repositories.
 	// If not provided, the provider's default pull secret is used.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=262144
 	PullSecret string `json:"pullSecret,omitempty"`
 	// SSHPublicKey is an SSH public key installed on cluster worker nodes.
 	// If not provided, the provider's default SSH key is used.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=16384
 	SSHPublicKey string `json:"sshPublicKey,omitempty"`
 	// ReleaseImage is the OCP release image URL that controls the OpenShift version.
 	// If not provided, the template's default release image is used.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=512
+	// +kubebuilder:validation:Pattern=`.+/.+:.+`
 	ReleaseImage string `json:"releaseImage,omitempty"`
 	// Network contains cluster networking configuration.
 	// +kubebuilder:validation:Optional
@@ -63,11 +67,13 @@ type ClusterNetworkSpec struct {
 	// PodCIDR is the CIDR for the cluster's pod network.
 	// Defaults to 10.128.0.0/14 if not specified.
 	// +kubebuilder:validation:Optional
+	// Coarse format check only — full CIDR validation (e.g. net.ParseCIDR) is done server-side.
 	// +kubebuilder:validation:Pattern=`^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`
 	PodCIDR string `json:"podCIDR,omitempty"`
 	// ServiceCIDR is the CIDR for the cluster's service network.
 	// Defaults to 172.30.0.0/16 if not specified.
 	// +kubebuilder:validation:Optional
+	// Coarse format check only — full CIDR validation (e.g. net.ParseCIDR) is done server-side.
 	// +kubebuilder:validation:Pattern=`^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`
 	ServiceCIDR string `json:"serviceCIDR,omitempty"`
 }

--- a/config/crd/bases/osac.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/osac.openshift.io_clusterorders.yaml
@@ -97,7 +97,7 @@ spec:
                   ReleaseImage is the OCP release image URL that controls the OpenShift version.
                   If not provided, the template's default release image is used.
                 maxLength: 512
-                pattern: .+/.+:.+
+                pattern: ^.+/.+:.+$
                 type: string
               sshPublicKey:
                 description: |-

--- a/config/crd/bases/osac.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/osac.openshift.io_clusterorders.yaml
@@ -55,12 +55,14 @@ spec:
                     description: |-
                       PodCIDR is the CIDR for the cluster's pod network.
                       Defaults to 10.128.0.0/14 if not specified.
+                      Coarse format check only — full CIDR validation (e.g. net.ParseCIDR) is done server-side.
                     pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
                     type: string
                   serviceCIDR:
                     description: |-
                       ServiceCIDR is the CIDR for the cluster's service network.
                       Defaults to 172.30.0.0/16 if not specified.
+                      Coarse format check only — full CIDR validation (e.g. net.ParseCIDR) is done server-side.
                     pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
                     type: string
                 type: object
@@ -88,16 +90,20 @@ spec:
                 description: |-
                   PullSecret contains credentials for authenticating to container image repositories.
                   If not provided, the provider's default pull secret is used.
+                maxLength: 262144
                 type: string
               releaseImage:
                 description: |-
                   ReleaseImage is the OCP release image URL that controls the OpenShift version.
                   If not provided, the template's default release image is used.
+                maxLength: 512
+                pattern: .+/.+:.+
                 type: string
               sshPublicKey:
                 description: |-
                   SSHPublicKey is an SSH public key installed on cluster worker nodes.
                   If not provided, the provider's default SSH key is used.
+                maxLength: 16384
                 type: string
               templateID:
                 description: TemplateID is the unique identigier of the cluster template

--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -642,11 +642,6 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 	}
 
-	instance.Status.TenantReference = &v1alpha1.TenantReferenceType{
-		Name:      tenant.Name,
-		Namespace: tenant.Status.Namespace,
-	}
-
 	targetClient, err := r.getTargetClient(ctx)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -642,6 +642,11 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 	}
 
+	instance.Status.TenantReference = &v1alpha1.TenantReferenceType{
+		Name:      tenant.Name,
+		Namespace: tenant.Status.Namespace,
+	}
+
 	targetClient, err := r.getTargetClient(ctx)
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
## Summary
Address review feedback from #186:
- Add `MaxLength` to `pullSecret` (256KB), `sshPublicKey` (16KB), `releaseImage` (512) to prevent oversized CRs stressing etcd
- Add basic pattern validation to `releaseImage` (must contain `/` and `:`) to catch obvious typos at admission time
- Add clarifying comments on CIDR regex noting it's a coarse format check — full validation via `net.ParseCIDR` is done server-side

## Test plan
- [x] `make manifests generate` — CRD regenerated
- [x] `make lint` passes
- [x] `make test` — all 275 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added maximum-length validations for SSH public key, pull secret, and release image fields.
  * Added format validation for release image values to enforce proper image reference structure.
  * Record tenant reference immediately once a tenant is confirmed ready, improving status accuracy.

* **Documentation**
  * Clarified that network CIDR validation is a coarse client-side check and full CIDR validation occurs server-side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->