### PR TITLE
ComputeInstance VM provisioned in tenant namespace instead of subnet namespace

### DIFF
--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -592,12 +592,12 @@ func (r *ComputeInstanceReconciler) syncMetadataPreflight(ctx context.Context, i
 		if err := r.Update(ctx, instance); err != nil {
 			return "", err
 		}
-		// Re-fetch so we have the latest resourceVersion and status; Update() may not
-		// return the full status (status subresource is separate), and we need the
-		// latest version to avoid 409 conflicts on later status updates.
-		if err := r.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
-			return "", err
-		}
+		// r.Update() returns the full server response via .Into(obj): the annotation
+		// we just wrote, the latest ResourceVersion, and the current server-side status
+		// are all present in instance after this call. No re-fetch is needed.
+		// A cache-based r.Get() here would race against the async watch stream and
+		// return a stale version that wipes the annotation from instance before it
+		// reaches the AAP/EDA payload in handleProvisioning.
 	}
 
 	return subnetTargetNamespace, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced redundant background reads during metadata updates, streamlining reconciliation and lowering transient conflict likelihood.
  * Improves internal efficiency and stability of update flows, resulting in marginally faster and more reliable processing without changing visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->