### PR TITLE
MGMT-23735: Add parent publicippool name annotation on publicip CR

### DIFF
--- a/internal/controller/constants_common.go
+++ b/internal/controller/constants_common.go
@@ -34,6 +34,10 @@ const (
 	// (e.g., "cudn" -> cudn_virtual_network or cudn_subnet role).
 	osacImplementationStrategyAnnotation = osacPrefix + "/implementation-strategy"
 
+	// osacPublicIPPoolNameAnnotation is the K8s resource name of the parent PublicIPPool.
+	// set on PublicIP CRs
+	osacPublicIPPoolNameAnnotation = osacPrefix + "/publicippool-name"
+
 	// defaultPublicIPPoolImplementationStrategy is the fallback strategy when none is specified.
 	// Used by PublicIPPool (from its own spec) and PublicIP (inherited from parent pool).
 	defaultPublicIPPoolImplementationStrategy = "metallb-l2"

--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -190,9 +190,18 @@ func (r *PublicIPReconciler) handleUpdate(ctx context.Context, publicIP *v1alpha
 	if publicIP.Annotations == nil {
 		publicIP.Annotations = make(map[string]string)
 	}
+	needsUpdate := false
 	if publicIP.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
 		publicIP.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
 		log.Info("setting implementation-strategy annotation", "strategy", implementationStrategy)
+		needsUpdate = true
+	}
+	if publicIP.Annotations[osacPublicIPPoolNameAnnotation] != pool.Name {
+		publicIP.Annotations[osacPublicIPPoolNameAnnotation] = pool.Name
+		log.Info("setting publicippool-name annotation", "poolName", pool.Name)
+		needsUpdate = true
+	}
+	if needsUpdate {
 		if err := r.Update(ctx, publicIP); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -177,6 +177,7 @@ var _ = Describe("PublicIPReconciler", func() {
 			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			Expect(updated.Annotations[osacPublicIPPoolNameAnnotation]).To(Equal("pool-k8s-name"))
 		})
 
 		It("should requeue when parent PublicIPPool is not found", func() {
@@ -248,6 +249,7 @@ var _ = Describe("PublicIPReconciler", func() {
 			updated := &osacv1alpha1.PublicIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultPublicIPPoolImplementationStrategy))
+			Expect(updated.Annotations[osacPublicIPPoolNameAnnotation]).To(Equal("pool-no-strategy"))
 		})
 
 		It("should set ConfigurationApplied condition to True", func() {


### PR DESCRIPTION
Aims to support [MGMT-23735](https://redhat.atlassian.net/browse/MGMT-23907).

The `metallb.universe.tf/address-pool` we need to set in the AAP role needs access to the parent public ip pool k8s resource name.  Currently we only have the fulfillment-service generated uuid in the spec.pool, this adds an additional annotation so we can easily set the metallb value without additional round trips looking that info up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PublicIP resources now include an annotation tracking their parent PublicIPPool reference.

* **Improvements**
  * Enhanced annotation update efficiency by consolidating multiple metadata changes into a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->