### PR TITLE
MGMT-23736/MGMT-23987: add Attaching state to PublicIP CRD

### DIFF
--- a/api/v1alpha1/publicip_types.go
+++ b/api/v1alpha1/publicip_types.go
@@ -63,6 +63,9 @@ const (
 	// PublicIPStateAllocated means the IP has been allocated from the pool
 	PublicIPStateAllocated PublicIPStateType = "Allocated"
 
+	// PublicIPStateAttaching means the IP is being attached to a ComputeInstance
+	PublicIPStateAttaching PublicIPStateType = "Attaching"
+
 	// PublicIPStateAttached means the IP is attached to a ComputeInstance
 	PublicIPStateAttached PublicIPStateType = "Attached"
 
@@ -100,7 +103,7 @@ type PublicIPStatus struct {
 	// State tracks the attachment lifecycle of the PublicIP
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Enum=Pending;Allocated;Attached;Releasing;Failed
+	// +kubebuilder:validation:Enum=Pending;Allocated;Attaching;Attached;Releasing;Failed
 	State PublicIPStateType `json:"state,omitempty"`
 }
 

--- a/config/crd/bases/osac.openshift.io_publicips.yaml
+++ b/config/crd/bases/osac.openshift.io_publicips.yaml
@@ -215,6 +215,7 @@ spec:
                 enum:
                 - Pending
                 - Allocated
+                - Attaching
                 - Attached
                 - Releasing
                 - Failed


### PR DESCRIPTION
## Summary

Adds the `Attaching` intermediate state to the PublicIP CRD state enum, between
`Allocated` and `Attached`. This supports the asynchronous attach flow where a
MetalLB LoadBalancer Service must be moved to the target ComputeInstance's namespace
via AAP before the IP is fully attached.

This mirrors the existing `Releasing` intermediate state on the detach side, giving
the full lifecycle symmetry:

```
Pending -> Allocated -> Attaching -> Attached -> Releasing -> Allocated
```

Part of [MGMT-23736](https://redhat.atlassian.net/browse/MGMT-23736) (PublicIP attachment to ComputeInstance).

## Changes

- Added `PublicIPStateAttaching` constant to `api/v1alpha1/publicip_types.go`
- Updated kubebuilder `Enum` validation marker to include `Attaching`
- Regenerated CRD manifest via `make manifests generate`

## Testing

```
$ make lint
0 issues.

$ make test
ok  github.com/osac-project/osac-operator/cmd          coverage: 4.9%
ok  github.com/osac-project/osac-operator/helpers       coverage: 95.5%
ok  github.com/osac-project/osac-operator/internal/aap  coverage: 84.9%
ok  github.com/osac-project/osac-operator/internal/controller  coverage: 62.0%
ok  github.com/osac-project/osac-operator/internal/provisioning  coverage: 73.7%
```

## Related PRs

- fulfillment-service PR (forthcoming): adds `PUBLIC_IP_STATE_ATTACHING` to the proto
  enum and implements attach/detach validation (MGMT-23986, [MGMT-23987](https://redhat.atlassian.net/browse/MGMT-23987), MGMT-23988, [MGMT-23994](https://redhat.atlassian.net/browse/MGMT-23994))

## Ticket

- [MGMT-23736](https://redhat.atlassian.net/browse/MGMT-23736): PublicIP Attachment: ComputeInstance attach/detach operations
  - [MGMT-23987](https://redhat.atlassian.net/browse/MGMT-23987): Implement attach validation in PublicIP server (subtask)

<br>

<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `Attaching` status state for public IP resources, enabling the system to report intermediate attachment lifecycle states. This provides better visibility into the attachment process beyond previous pending/allocated/attached states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->