### PR TITLE
fix: add Claude Code pre-PR hooks to run lint and tests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(cat - | jq -r '.tool_input.file_path // .tool_input.filePath // empty') && case \"$file_path\" in *go.mod) cd \"$CLAUDE_PROJECT_DIR\" && go mod tidy ;; *_types.go) cd \"$CLAUDE_PROJECT_DIR\" && make manifests generate ;; esac"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(cat - | jq -r '.tool_input.command // empty') && case \"$cmd\" in *'gh pr create'*) cd \"$CLAUDE_PROJECT_DIR\" && { BEFORE=$(git diff --name-only) && make fmt && AFTER=$(git diff --name-only) && test \"$BEFORE\" = \"$AFTER\" || { echo 'gofmt changed files — commit the formatting fixes first' >&2; exit 2; }; } && make lint && make test || exit 2 ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,3 +25,5 @@ jobs:
           go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@ OSAC operator is a Kubernetes operator that reconciles infrastructure resources 
 - **Never edit** `config/crd/`, `zz_generated.deepcopy.go`, or `internal/api/` — all generated
 - **Always `buf generate`** after updating the module version in `buf.gen.yaml`
 - **Commit message format**: `MGMT-XXXXX: description of change`
-- Run `make lint test` before committing
+- **Always `make lint` before committing or creating PRs** — CI runs `golangci-lint` (including `goconst`) and will reject PRs with lint failures
+- Run `make test` before committing
+- **Use constants for repeated string literals** — the `goconst` linter flags strings with 3+ occurrences; define them as `const` or package-level `var`
 
 ## Development Commands
 
@@ -102,6 +104,14 @@ test/e2e/                  # End-to-end tests
 - Pre-commit hooks in `.pre-commit-config.yaml`: whitespace, yamllint, golangci-lint
 - Linter config in `.golangci.yml`
 - Run manually: `pre-commit run --all-files`
+
+## Claude Code Hooks
+
+Hooks are configured in `.claude/settings.json` and run automatically during Claude Code sessions:
+
+- **CRD type changes** (`PostToolUse`): When `*_types.go` is edited, `make manifests generate` runs automatically.
+- **Go module changes** (`PostToolUse`): When `go.mod` is edited, `go mod tidy` runs automatically.
+- **Pre-PR** (`PreToolUse`): `make fmt` (fails if files changed — commit fixes first), `make lint`, and `make test` run before `gh pr create`.
 
 ## Detailed Rules (auto-loaded from `.claude/rules/`)
 


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with hooks that gate `gh pr create` on `make fmt`, `make lint`, and `make test` passing
- Auto-runs `make manifests generate` when CRD `*_types.go` files are edited
- Auto-runs `go mod tidy` when `go.mod` is edited

This prevents AI-authored PRs (like #214) from being submitted with lint failures such as `goconst` violations.

## Test plan
- [ ] Open Claude Code in osac-operator and attempt `gh pr create` with a goconst violation — hook should block it
- [ ] Edit a `*_types.go` file — `make manifests generate` should run automatically
- [ ] Edit `go.mod` — `go mod tidy` should run automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development tooling automation to strengthen code quality and consistency enforcement across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->