### PR TITLE
MGMT-23989: Add publicip target namespace annotation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -442,6 +442,7 @@ func setupNetworkingControllers(
 
 	// Get namespace from environment (single namespace for all networking resources)
 	networkingNamespace := os.Getenv(envNetworkingNamespace)
+	computeInstanceNamespace := os.Getenv(envComputeInstanceNamespace)
 
 	// Get provider configuration
 	aapURL := os.Getenv(envAAPURL)
@@ -525,8 +526,9 @@ func setupNetworkingControllers(
 	}
 
 	// Setup PublicIP controller
-	if err := controller.NewPublicIPReconciler(mgr, networkingNamespace, networkingProvider, statusPollInterval,
-		maxJobHistory, targetCluster,
+	if err := controller.NewPublicIPReconciler(
+		mgr, networkingNamespace, computeInstanceNamespace,
+		networkingProvider, statusPollInterval, maxJobHistory, targetCluster,
 	).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("publicip controller: %w", err)
 	}

--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -51,20 +51,22 @@ const (
 // Phase transitions: "" -> Progressing -> Ready/Failed; on delete: Deleting.
 type PublicIPReconciler struct {
 	client.Client
-	APIReader            client.Reader
-	Scheme               *runtime.Scheme
-	mgr                  mcmanager.Manager
-	NetworkingNamespace  string
-	ProvisioningProvider provisioning.ProvisioningProvider
-	StatusPollInterval   time.Duration
-	MaxJobHistory        int
-	targetCluster        mc.ClusterName
+	APIReader                client.Reader
+	Scheme                   *runtime.Scheme
+	mgr                      mcmanager.Manager
+	NetworkingNamespace      string
+	ComputeInstanceNamespace string
+	ProvisioningProvider     provisioning.ProvisioningProvider
+	StatusPollInterval       time.Duration
+	MaxJobHistory            int
+	targetCluster            mc.ClusterName
 }
 
 // NewPublicIPReconciler creates a new reconciler for PublicIP resources.
 func NewPublicIPReconciler(
 	mgr mcmanager.Manager,
 	networkingNamespace string,
+	computeInstanceNamespace string,
 	provisioningProvider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration,
 	maxJobHistory int,
@@ -80,15 +82,16 @@ func NewPublicIPReconciler(
 		maxJobHistory = provisioning.DefaultMaxJobHistory
 	}
 	return &PublicIPReconciler{
-		Client:               mgr.GetLocalManager().GetClient(),
-		APIReader:            mgr.GetLocalManager().GetAPIReader(),
-		Scheme:               mgr.GetLocalManager().GetScheme(),
-		mgr:                  mgr,
-		NetworkingNamespace:  networkingNamespace,
-		ProvisioningProvider: provisioningProvider,
-		StatusPollInterval:   statusPollInterval,
-		MaxJobHistory:        maxJobHistory,
-		targetCluster:        targetCluster,
+		Client:                   mgr.GetLocalManager().GetClient(),
+		APIReader:                mgr.GetLocalManager().GetAPIReader(),
+		Scheme:                   mgr.GetLocalManager().GetScheme(),
+		mgr:                      mgr,
+		NetworkingNamespace:      networkingNamespace,
+		ComputeInstanceNamespace: computeInstanceNamespace,
+		ProvisioningProvider:     provisioningProvider,
+		StatusPollInterval:       statusPollInterval,
+		MaxJobHistory:            maxJobHistory,
+		targetCluster:            targetCluster,
 	}
 }
 
@@ -96,6 +99,7 @@ func NewPublicIPReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=publicips/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=publicips/finalizers,verbs=update
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=publicippools,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=computeinstances,verbs=get;list;watch
 
 // Reconcile handles create/update/delete for a PublicIP CR.
 // On create/update it ensures a finalizer, resolves the parent pool, and runs provisioning.
@@ -185,12 +189,21 @@ func (r *PublicIPReconciler) handleUpdate(ctx context.Context, publicIP *v1alpha
 		implementationStrategy = defaultPublicIPPoolImplementationStrategy
 	}
 
-	// Annotate the CR so AAP playbooks can select the appropriate role without
-	// having to look up the parent pool themselves.
 	if publicIP.Annotations == nil {
 		publicIP.Annotations = make(map[string]string)
 	}
-	needsUpdate := false
+
+	// Resolve the target namespace for the ComputeInstance attachment, if any.
+	needsUpdate, requeueForCI, err := r.syncComputeInstanceTargetNamespaceAnnotation(ctx, publicIP)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if requeueForCI {
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+
+	// Annotate the CR so AAP playbooks can select the appropriate role without
+	// having to look up the parent pool themselves.
 	if publicIP.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
 		publicIP.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
 		log.Info("setting implementation-strategy annotation", "strategy", implementationStrategy)
@@ -238,6 +251,55 @@ func (r *PublicIPReconciler) handleUpdate(ctx context.Context, publicIP *v1alpha
 	}
 
 	return r.handleProvisioning(ctx, publicIP)
+}
+
+// syncComputeInstanceTargetNamespaceAnnotation resolves the tenant namespace for the
+// ComputeInstance referenced by spec.computeInstance and writes it as an annotation.
+// When spec.computeInstance is cleared, the annotation is removed.
+func (r *PublicIPReconciler) syncComputeInstanceTargetNamespaceAnnotation(
+	ctx context.Context, publicIP *v1alpha1.PublicIP,
+) (changed bool, requeue bool, err error) {
+	log := ctrllog.FromContext(ctx)
+
+	if publicIP.Spec.ComputeInstance == "" {
+		if _, ok := publicIP.Annotations[osacPublicIPTargetNamespaceAnnotation]; ok {
+			delete(publicIP.Annotations, osacPublicIPTargetNamespaceAnnotation)
+			log.Info("cleared publicip-target-namespace annotation")
+			return true, false, nil
+		}
+		return false, false, nil
+	}
+
+	ciList := &v1alpha1.ComputeInstanceList{}
+	if err := r.List(ctx, ciList,
+		client.InNamespace(r.ComputeInstanceNamespace),
+		client.MatchingLabels{osacComputeInstanceIDLabel: publicIP.Spec.ComputeInstance},
+	); err != nil {
+		return false, false, err
+	}
+	if len(ciList.Items) == 0 {
+		log.Info("ComputeInstance not found, requeueing", "computeInstanceUUID", publicIP.Spec.ComputeInstance)
+		return false, true, nil
+	}
+
+	ci := &ciList.Items[0]
+	if ci.Status.TenantReference == nil {
+		log.Info("ComputeInstance has no TenantReference yet, requeueing",
+			"computeInstance", ci.Name, "computeInstanceUUID", publicIP.Spec.ComputeInstance)
+		return false, true, nil
+	}
+
+	targetNamespace := ci.Status.TenantReference.Namespace
+	if publicIP.Annotations == nil {
+		publicIP.Annotations = make(map[string]string)
+	}
+	if publicIP.Annotations[osacPublicIPTargetNamespaceAnnotation] != targetNamespace {
+		publicIP.Annotations[osacPublicIPTargetNamespaceAnnotation] = targetNamespace
+		log.Info("setting publicip-target-namespace annotation", "targetNamespace", targetNamespace)
+		return true, false, nil
+	}
+
+	return false, false, nil
 }
 
 // handleDelete sets the Deleting phase, runs deprovisioning, and removes the finalizer

--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -81,6 +81,9 @@ func NewPublicIPReconciler(
 	if maxJobHistory <= 0 {
 		maxJobHistory = provisioning.DefaultMaxJobHistory
 	}
+	if computeInstanceNamespace == "" {
+		computeInstanceNamespace = defaultComputeInstanceNamespace
+	}
 	return &PublicIPReconciler{
 		Client:                   mgr.GetLocalManager().GetClient(),
 		APIReader:                mgr.GetLocalManager().GetAPIReader(),

--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -28,7 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mc "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
@@ -256,7 +258,7 @@ func (r *PublicIPReconciler) handleUpdate(ctx context.Context, publicIP *v1alpha
 	return r.handleProvisioning(ctx, publicIP)
 }
 
-// syncComputeInstanceTargetNamespaceAnnotation resolves the tenant namespace for the
+// syncComputeInstanceTargetNamespaceAnnotation resolves the VM namespace for the
 // ComputeInstance referenced by spec.computeInstance and writes it as an annotation.
 // When spec.computeInstance is cleared, the annotation is removed.
 func (r *PublicIPReconciler) syncComputeInstanceTargetNamespaceAnnotation(
@@ -273,6 +275,13 @@ func (r *PublicIPReconciler) syncComputeInstanceTargetNamespaceAnnotation(
 		return false, false, nil
 	}
 
+	if r.ComputeInstanceNamespace == "" {
+		return false, false, fmt.Errorf(
+			"ComputeInstanceNamespace is not configured; cannot resolve target namespace for computeInstance %q",
+			publicIP.Spec.ComputeInstance,
+		)
+	}
+
 	ciList := &v1alpha1.ComputeInstanceList{}
 	if err := r.List(ctx, ciList,
 		client.InNamespace(r.ComputeInstanceNamespace),
@@ -286,13 +295,13 @@ func (r *PublicIPReconciler) syncComputeInstanceTargetNamespaceAnnotation(
 	}
 
 	ci := &ciList.Items[0]
-	if ci.Status.TenantReference == nil {
-		log.Info("ComputeInstance has no TenantReference yet, requeueing",
+	if ci.Status.VirtualMachineReference == nil {
+		log.Info("ComputeInstance has no VirtualMachineReference yet, requeueing",
 			"computeInstance", ci.Name, "computeInstanceUUID", publicIP.Spec.ComputeInstance)
 		return false, true, nil
 	}
 
-	targetNamespace := ci.Status.TenantReference.Namespace
+	targetNamespace := ci.Status.VirtualMachineReference.Namespace
 	if publicIP.Annotations == nil {
 		publicIP.Annotations = make(map[string]string)
 	}
@@ -443,12 +452,58 @@ func (r *PublicIPReconciler) handleDeprovisioning(ctx context.Context, publicIP 
 }
 
 // SetupWithManager registers this controller with the multicluster manager.
-// It watches PublicIP CRs in the networking namespace on the local cluster only.
+// It watches PublicIP CRs in the networking namespace on the local cluster only,
+// and also watches ComputeInstance resources so that PublicIPs reconcile immediately
+// when a referenced CI's status changes (e.g., VirtualMachineReference is set).
 func (r *PublicIPReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	return mcbuilder.ControllerManagedBy(mgr).
 		For(&v1alpha1.PublicIP{},
 			mcbuilder.WithPredicates(NetworkingNamespacePredicate(r.NetworkingNamespace)),
 			mcbuilder.WithEngageWithLocalCluster(true),
 			mcbuilder.WithEngageWithProviderClusters(false)).
+		Watches(
+			&v1alpha1.ComputeInstance{},
+			mchandler.EnqueueRequestsFromMapFunc(r.mapComputeInstanceToPublicIPs),
+			mcbuilder.WithPredicates(ComputeInstanceNamespacePredicate(r.ComputeInstanceNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false),
+		).
 		Complete(r)
+}
+
+// mapComputeInstanceToPublicIPs maps a ComputeInstance change to all PublicIPs
+// that reference it via spec.computeInstance, so the PublicIP reconciler can
+// update the target namespace annotation when the CI's VM reference appears.
+func (r *PublicIPReconciler) mapComputeInstanceToPublicIPs(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := ctrllog.FromContext(ctx)
+
+	ciUUID, exists := obj.GetLabels()[osacComputeInstanceIDLabel]
+	if !exists {
+		return nil
+	}
+
+	publicIPs := &v1alpha1.PublicIPList{}
+	if err := r.List(ctx, publicIPs, client.InNamespace(r.NetworkingNamespace)); err != nil {
+		log.Error(err, "failed to list PublicIPs for ComputeInstance watch")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range publicIPs.Items {
+		if publicIPs.Items[i].Spec.ComputeInstance == ciUUID {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&publicIPs.Items[i]),
+			})
+		}
+	}
+
+	if len(requests) > 0 {
+		log.Info("mapped ComputeInstance change to PublicIPs",
+			"computeInstance", obj.GetName(),
+			"computeInstanceUUID", ciUUID,
+			"publicIPCount", len(requests),
+		)
+	}
+
+	return requests
 }

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -503,6 +503,181 @@ var _ = Describe("PublicIPReconciler", func() {
 		})
 	})
 
+	Context("ComputeInstance target namespace annotation", func() {
+		const (
+			testCINamespace = "osac-computeinstance"
+			testCIUUID      = "ci-uuid-456"
+			testTenantNS    = "tenant-ns-abc"
+		)
+
+		It("should set publicip-target-namespace annotation when computeInstance is set", func() {
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ci",
+					Namespace: testCINamespace,
+					Labels: map[string]string{
+						osacComputeInstanceIDLabel: testCIUUID,
+					},
+				},
+			}
+
+			ipWithCI := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-with-ci",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: testCIUUID,
+				},
+			}
+
+			ciClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(ipWithCI, parentPool, ci).
+				WithStatusSubresource(&osacv1alpha1.PublicIP{}, &osacv1alpha1.ComputeInstance{}).
+				Build()
+
+			// Apply status separately — WithStatusSubresource strips status from WithObjects.
+			ci.Status.TenantReference = &osacv1alpha1.TenantReferenceType{
+				Name:      "test-tenant",
+				Namespace: testTenantNS,
+			}
+			Expect(ciClient.Status().Update(testCtx, ci)).To(Succeed())
+
+			reconciler.Client = ciClient
+			reconciler.APIReader = ciClient
+			reconciler.ComputeInstanceNamespace = testCINamespace
+
+			key := types.NamespacedName{Name: ipWithCI.Name, Namespace: ipWithCI.Namespace}
+
+			// Pass 1: adds finalizer
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Pass 2: resolves pool and CI annotations
+			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.PublicIP{}
+			Expect(ciClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacPublicIPTargetNamespaceAnnotation]).To(Equal(testTenantNS))
+		})
+
+		It("should clear publicip-target-namespace annotation when computeInstance is cleared", func() {
+			ipWithAnnotation := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-clear-ci",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						osacPublicIPTargetNamespaceAnnotation: testTenantNS,
+					},
+					Finalizers: []string{osacPublicIPFinalizer},
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool: testPoolUUID,
+				},
+			}
+
+			clearClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(ipWithAnnotation, parentPool).
+				WithStatusSubresource(&osacv1alpha1.PublicIP{}).
+				Build()
+
+			reconciler.Client = clearClient
+			reconciler.APIReader = clearClient
+
+			key := types.NamespacedName{Name: ipWithAnnotation.Name, Namespace: ipWithAnnotation.Namespace}
+
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.PublicIP{}
+			Expect(clearClient.Get(testCtx, key, updated)).To(Succeed())
+			_, exists := updated.Annotations[osacPublicIPTargetNamespaceAnnotation]
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should requeue when ComputeInstance not found", func() {
+			ipMissingCI := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-missing-ci",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: "nonexistent-ci-uuid",
+				},
+			}
+
+			missingClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(ipMissingCI, parentPool).
+				WithStatusSubresource(&osacv1alpha1.PublicIP{}).
+				Build()
+
+			reconciler.Client = missingClient
+			reconciler.APIReader = missingClient
+			reconciler.ComputeInstanceNamespace = testCINamespace
+
+			key := types.NamespacedName{Name: ipMissingCI.Name, Namespace: ipMissingCI.Namespace}
+
+			// Pass 1: adds finalizer
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Pass 2: CI not found, requeue
+			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+
+		It("should requeue when ComputeInstance has no TenantReference", func() {
+			ciNoTenant := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-no-tenant",
+					Namespace: testCINamespace,
+					Labels: map[string]string{
+						osacComputeInstanceIDLabel: testCIUUID,
+					},
+				},
+			}
+
+			ipNoTenant := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-no-tenant",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: testCIUUID,
+				},
+			}
+
+			noTenantClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(ipNoTenant, parentPool, ciNoTenant).
+				WithStatusSubresource(&osacv1alpha1.PublicIP{}, &osacv1alpha1.ComputeInstance{}).
+				Build()
+
+			reconciler.Client = noTenantClient
+			reconciler.APIReader = noTenantClient
+			reconciler.ComputeInstanceNamespace = testCINamespace
+
+			key := types.NamespacedName{Name: ipNoTenant.Name, Namespace: ipNoTenant.Namespace}
+
+			// Pass 1: adds finalizer
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Pass 2: CI found but no TenantReference, requeue
+			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+	})
+
 	// The provisioning lifecycle uses a config version (hash of spec + strategy) to
 	// detect spec changes. When provisioning fails, the controller backs off with
 	// exponential delay. But if the spec changes (new config version), it retries

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
@@ -675,6 +676,156 @@ var _ = Describe("PublicIPReconciler", func() {
 			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+	})
+
+	Context("mapComputeInstanceToPublicIPs", func() {
+		const (
+			mapTestCINamespace = "osac-computeinstance"
+			mapTestCIUUID      = "ci-map-uuid-789"
+		)
+
+		It("should return requests for PublicIPs referencing the ComputeInstance UUID", func() {
+			matchingIP := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-matching",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: mapTestCIUUID,
+				},
+			}
+			unrelatedIP := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-unrelated",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: "other-ci-uuid",
+				},
+			}
+
+			mapClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(matchingIP, unrelatedIP).
+				Build()
+
+			reconciler.Client = mapClient
+			reconciler.NetworkingNamespace = testNamespace
+			reconciler.ComputeInstanceNamespace = mapTestCINamespace
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ci",
+					Namespace: mapTestCINamespace,
+					Labels: map[string]string{
+						osacComputeInstanceIDLabel: mapTestCIUUID,
+					},
+				},
+			}
+
+			requests := reconciler.mapComputeInstanceToPublicIPs(testCtx, ci)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName).To(Equal(types.NamespacedName{
+				Name:      "ip-matching",
+				Namespace: testNamespace,
+			}))
+		})
+
+		It("should return nil when ComputeInstance has no UUID label", func() {
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-no-label",
+					Namespace: mapTestCINamespace,
+				},
+			}
+
+			requests := reconciler.mapComputeInstanceToPublicIPs(testCtx, ci)
+			Expect(requests).To(BeNil())
+		})
+
+		It("should return empty when no PublicIPs reference the ComputeInstance", func() {
+			unrelatedIP := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-no-match",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: "different-uuid",
+				},
+			}
+
+			mapClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(unrelatedIP).
+				Build()
+
+			reconciler.Client = mapClient
+			reconciler.NetworkingNamespace = testNamespace
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-no-matches",
+					Namespace: mapTestCINamespace,
+					Labels: map[string]string{
+						osacComputeInstanceIDLabel: mapTestCIUUID,
+					},
+				},
+			}
+
+			requests := reconciler.mapComputeInstanceToPublicIPs(testCtx, ci)
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should return multiple requests when several PublicIPs reference the same ComputeInstance", func() {
+			ip1 := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-multi-1",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: mapTestCIUUID,
+				},
+			}
+			ip2 := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-multi-2",
+					Namespace: testNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: mapTestCIUUID,
+				},
+			}
+
+			mapClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(ip1, ip2).
+				Build()
+
+			reconciler.Client = mapClient
+			reconciler.NetworkingNamespace = testNamespace
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-multi",
+					Namespace: mapTestCINamespace,
+					Labels: map[string]string{
+						osacComputeInstanceIDLabel: mapTestCIUUID,
+					},
+				},
+			}
+
+			requests := reconciler.mapComputeInstanceToPublicIPs(testCtx, ci)
+			Expect(requests).To(HaveLen(2))
+			Expect(requests).To(ContainElements(
+				reconcile.Request{NamespacedName: types.NamespacedName{Name: "ip-multi-1", Namespace: testNamespace}},
+				reconcile.Request{NamespacedName: types.NamespacedName{Name: "ip-multi-2", Namespace: testNamespace}},
+			))
 		})
 	})
 

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -539,9 +539,9 @@ var _ = Describe("PublicIPReconciler", func() {
 				Build()
 
 			// Apply status separately — WithStatusSubresource strips status from WithObjects.
-			ci.Status.TenantReference = &osacv1alpha1.TenantReferenceType{
-				Name:      "test-tenant",
-				Namespace: testTenantNS,
+			ci.Status.VirtualMachineReference = &osacv1alpha1.VirtualMachineReferenceType{
+				Namespace:                  testTenantNS,
+				KubeVirtVirtualMachineName: "test-vm",
 			}
 			Expect(ciClient.Status().Update(testCtx, ci)).To(Succeed())
 
@@ -633,7 +633,7 @@ var _ = Describe("PublicIPReconciler", func() {
 			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
 		})
 
-		It("should requeue when ComputeInstance has no TenantReference", func() {
+		It("should requeue when ComputeInstance has no VirtualMachineReference", func() {
 			ciNoTenant := &osacv1alpha1.ComputeInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ci-no-tenant",
@@ -671,7 +671,7 @@ var _ = Describe("PublicIPReconciler", func() {
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Pass 2: CI found but no TenantReference, requeue
+			// Pass 2: CI found but no VirtualMachineReference, requeue
 			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))

--- a/internal/controller/publicip_names.go
+++ b/internal/controller/publicip_names.go
@@ -18,6 +18,7 @@ import (
 )
 
 var (
-	osacPublicIPIDLabel           string = fmt.Sprintf("%s/publicip-uuid", osacPrefix)
-	osacPublicIPFeedbackFinalizer string = fmt.Sprintf("%s/publicip-feedback", osacPrefix)
+	osacPublicIPIDLabel                   string = fmt.Sprintf("%s/publicip-uuid", osacPrefix)
+	osacPublicIPFeedbackFinalizer         string = fmt.Sprintf("%s/publicip-feedback", osacPrefix)
+	osacPublicIPTargetNamespaceAnnotation string = fmt.Sprintf("%s/publicip-target-namespace", osacPrefix)
 )


### PR DESCRIPTION
[MGMT-23989](https://redhat.atlassian.net/browse/MGMT-23989)

Sets a `osac.openshift.io/publicip-target-namespace` annotation on the Public IP CR when `spec.computeInstance` is set.  This annotation will be used by AAP roles to know where to create the associated LoadBalancer Service for the given Public IP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PublicIP resources can now associate with ComputeInstance resources and automatically synchronize the target namespace annotation from the referenced instance.
  * Controller now watches ComputeInstance changes to keep PublicIP state up to date.

* **Tests**
  * Added tests validating annotation set/clear/requeue behaviors and mapping of ComputeInstances to affected PublicIPs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->