### PR TITLE
NO-ISSUE: adds kubeconform kube-linter and pre-push hooks to osac-operator

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -61,7 +61,7 @@ jobs:
         bin/kubeconform \
           -strict \
           -summary \
-          -kubernetes-version 1.31.0 \
+          -kubernetes-version 1.34.0 \
           -schema-location default \
           -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
           -ignore-missing-schemas \

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -12,7 +12,7 @@
 # the License.
 #
 
-name: check-generated-code
+name: check-pull-request
 
 on:
   pull_request:
@@ -31,3 +31,42 @@ jobs:
     - run: |
         buf generate
         git diff --exit-code
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+    - name: Check controller-gen output is up to date
+      run: |
+        make manifests generate
+        git diff --exit-code config/crd/ config/rbac/role.yaml api/v1alpha1/zz_generated.deepcopy.go
+
+  validate-manifests:
+    name: Validate manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Install tools
+      run: make kustomize kubeconform kube-linter
+
+    - name: Render and validate manifests
+      run: |
+        RENDERED="${RUNNER_TEMP}/rendered.yaml"
+        bin/kustomize build config/default > "$RENDERED"
+
+        bin/kubeconform \
+          -strict \
+          -summary \
+          -kubernetes-version 1.31.0 \
+          -schema-location default \
+          -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+          -ignore-missing-schemas \
+          "$RENDERED"
+
+        bin/kube-linter lint "$RENDERED" --config .kube-linter.yaml
+
+        rm -f "$RENDERED"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,26 +33,19 @@ linters:
   exclusions:
     generated: lax
     rules:
-      - linters:
-          - dupl
-          - lll
-        path: pkg/
+      # Long lines in controller/pkg code come from structured logging, K8s API calls,
+      # and gRPC type names — breaking them hurts readability more than the length
       - linters:
           - lll
-        path: api/
+        path: (internal/|pkg/)
+      # Feedback controllers share a reconcile skeleton by design (dual-controller pattern)
       - linters:
           - dupl
-          - lll
-        path: internal/
+        path: internal/controller/
+      # Test duplication is intentional — each test should be self-contained and readable
       - linters:
           - dupl
-        path: api/v1alpha1/clusterorder_clusterreference.go
-      - linters:
-          - dupl
-        path: api/v1alpha1/computeinstance_virtualmachinereference.go
-      - linters:
-          - errcheck
-        path: ".*_test.go$"
+        path: _test\.go
     paths:
       - third_party$
       - builtin$

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,44 @@
+checks:
+  addAllBuiltIn: true
+  exclude:
+    # The manager image uses `controller:latest` as a placeholder in config/manager/manager.yaml.
+    # The real image tag is injected by kustomize edit set image at build/deploy time.
+    - latest-tag
+
+    # The manager binds its health endpoints on :8081 via --health-probe-bind-address=:8081.
+    # Kubernetes does not require containerPort declarations for probes to function.
+    # Declaring the port is cosmetic; omitting it is the upstream operator-sdk scaffold default.
+    - liveness-port
+    - readiness-port
+
+    # The operator manager needs a writable filesystem (Go runtime tmp, controller-runtime caches).
+    # readOnlyRootFilesystem is not set in the upstream operator-sdk scaffold.
+    - no-read-only-root-fs
+
+    # Admin ClusterRoles intentionally use wildcard verbs — they are aggregated admin roles
+    # intended for human operators, not the controller itself.
+    - wildcard-in-rules
+
+    # Operator-sdk scaffold does not set dnsConfig. Standard cluster DNS is sufficient.
+    - dnsconfig-options
+
+    # Controller-manager runs as a single replica by design (leader-election for HA).
+    # Multiple replicas compete via lease, so minimum-three-replicas is inapplicable.
+    - minimum-three-replicas
+
+    # Operator pods do not declare node affinity; scheduling is left to the cluster default.
+    - no-node-affinity
+
+    # operator-sdk scaffold does not set updateStrategy on the Deployment explicitly.
+    # Kubernetes defaults to RollingUpdate, so this check produces a false positive.
+    - no-rolling-update-strategy
+
+    # NetworkPolicy is managed externally (osac-installer kustomize overlays).
+    - non-isolated-pod
+
+    # Ownership annotations and labels are not part of the operator-sdk scaffold convention.
+    - required-annotation-email
+    - required-label-owner
+
+    # Deployment has no explicit restartPolicy; Kubernetes defaults to Always for Deployments.
+    - restart-policy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,17 @@ repos:
     language: system
     files: \.go$
     entry: bin/golangci-lint run --fix
+
+  - id: kustomize-build
+    name: validate kustomize build
+    entry: bash -c 'bin/kustomize build config/default > /dev/null'
+    language: system
+    pass_filenames: false
+    stages: [pre-push]
+
+  - id: check-generated
+    name: check generated code is up to date
+    entry: bash -c 'make manifests generate && git diff --exit-code config/crd/ config/rbac/role.yaml api/v1alpha1/zz_generated.deepcopy.go'
+    language: system
+    pass_filenames: false
+    stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,20 @@ test/e2e/                  # End-to-end tests
 ## Code Quality
 
 - Pre-commit hooks in `.pre-commit-config.yaml`: whitespace, yamllint, golangci-lint
+- Pre-push hooks: kustomize-build, check-generated (manifest and code freshness)
 - Linter config in `.golangci.yml`
 - Run manually: `pre-commit run --all-files`
+
+### Hook Installation
+
+Two hook types must be installed separately:
+
+```bash
+pre-commit install                        # commit-stage hooks (lint, whitespace, etc.)
+pre-commit install --hook-type pre-push   # push-stage hooks (kustomize-build, check-generated)
+```
+
+Or use `make install-hooks` to install both at once.
 
 ## Automation Hooks
 

--- a/Makefile
+++ b/Makefile
@@ -362,13 +362,7 @@ set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-<<<<<<< HEAD
 GOTOOLCHAIN=$(GOTOOLCHAIN) GOBIN=$(LOCALBIN) go install $${package} ;\
-||||||| parent of 1a1c9b1 (NO-ISSUE: adds CI validation, lint tightening, and pre-push hooks)
-GOTOOLCHAIN=go1.25.0 GOBIN=$(LOCALBIN) go install $${package} ;\
-=======
-GOTOOLCHAIN=auto GOBIN=$(LOCALBIN) go install $${package} ;\
->>>>>>> 1a1c9b1 (NO-ISSUE: adds CI validation, lint tightening, and pre-push hooks)
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,11 @@ tag-api: ## Tag a new release of the api/ Go module (e.g. make tag-api API_VERSI
 		exit 1 ; \
 	fi
 
+.PHONY: install-hooks
+install-hooks: ## Install pre-commit hooks (commit-stage and pre-push).
+	pre-commit install
+	pre-commit install --hook-type pre-push
+
 ##@ Build
 
 .PHONY: build
@@ -306,12 +311,16 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+KUBECONFORM ?= $(LOCALBIN)/kubeconform
+KUBE_LINTER ?= $(LOCALBIN)/kube-linter
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.20.0
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v2.12.1
+KUBECONFORM_VERSION ?= v0.7.0
+KUBE_LINTER_VERSION ?= v0.7.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -333,6 +342,16 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
+.PHONY: kubeconform
+kubeconform: $(KUBECONFORM) ## Download kubeconform locally if necessary.
+$(KUBECONFORM): $(LOCALBIN)
+	$(call go-install-tool,$(KUBECONFORM),github.com/yannh/kubeconform/cmd/kubeconform,$(KUBECONFORM_VERSION))
+
+.PHONY: kube-linter
+kube-linter: $(KUBE_LINTER) ## Download kube-linter locally if necessary.
+$(KUBE_LINTER): $(LOCALBIN)
+	$(call go-install-tool,$(KUBE_LINTER),golang.stackrox.io/kube-linter/cmd/kube-linter,$(KUBE_LINTER_VERSION))
+
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
 # $2 - package url which can be installed
@@ -343,7 +362,13 @@ set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
+<<<<<<< HEAD
 GOTOOLCHAIN=$(GOTOOLCHAIN) GOBIN=$(LOCALBIN) go install $${package} ;\
+||||||| parent of 1a1c9b1 (NO-ISSUE: adds CI validation, lint tightening, and pre-push hooks)
+GOTOOLCHAIN=go1.25.0 GOBIN=$(LOCALBIN) go install $${package} ;\
+=======
+GOTOOLCHAIN=auto GOBIN=$(LOCALBIN) go install $${package} ;\
+>>>>>>> 1a1c9b1 (NO-ISSUE: adds CI validation, lint tightening, and pre-push hooks)
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)

--- a/helpers/getenvwithdefault_test.go
+++ b/helpers/getenvwithdefault_test.go
@@ -31,10 +31,7 @@ func TestGetEnvWithDefault_BackwardCompatibility(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envValue != "" {
-				os.Setenv(tt.envVar, tt.envValue)
-				defer os.Unsetenv(tt.envVar)
-			} else {
-				os.Unsetenv(tt.envVar)
+				t.Setenv(tt.envVar, tt.envValue)
 			}
 
 			switch expected := tt.expected.(type) {
@@ -70,8 +67,7 @@ func TestGetEnvWithDefault_BackwardCompatibility(t *testing.T) {
 
 // TestGetEnvWithDefault_SingleValidatorPass tests that valid values pass single validator
 func TestGetEnvWithDefault_SingleValidatorPass(t *testing.T) {
-	os.Setenv("TEST_PORT", "8080")
-	defer os.Unsetenv("TEST_PORT")
+	t.Setenv("TEST_PORT", "8080")
 
 	validator := func(v int) bool { return v > 0 && v < 65536 }
 	result := GetEnvWithDefault("TEST_PORT", 9000, validator)
@@ -83,8 +79,7 @@ func TestGetEnvWithDefault_SingleValidatorPass(t *testing.T) {
 
 // TestGetEnvWithDefault_SingleValidatorFail tests that invalid values use default
 func TestGetEnvWithDefault_SingleValidatorFail(t *testing.T) {
-	os.Setenv("TEST_PORT", "99999")
-	defer os.Unsetenv("TEST_PORT")
+	t.Setenv("TEST_PORT", "99999")
 
 	validator := func(v int) bool { return v > 0 && v < 65536 }
 	result := GetEnvWithDefault("TEST_PORT", 8080, validator)
@@ -96,8 +91,7 @@ func TestGetEnvWithDefault_SingleValidatorFail(t *testing.T) {
 
 // TestGetEnvWithDefault_MultipleValidatorsPass tests that all validators must pass
 func TestGetEnvWithDefault_MultipleValidatorsPass(t *testing.T) {
-	os.Setenv("TEST_PORT", "8080")
-	defer os.Unsetenv("TEST_PORT")
+	t.Setenv("TEST_PORT", "8080")
 
 	isPositive := func(v int) bool { return v > 0 }
 	isValidPort := func(v int) bool { return v < 65536 }
@@ -111,8 +105,7 @@ func TestGetEnvWithDefault_MultipleValidatorsPass(t *testing.T) {
 
 // TestGetEnvWithDefault_MultipleValidatorsFirstFails tests AND logic (short-circuit on first failure)
 func TestGetEnvWithDefault_MultipleValidatorsFirstFails(t *testing.T) {
-	os.Setenv("TEST_VALUE", "-5")
-	defer os.Unsetenv("TEST_VALUE")
+	t.Setenv("TEST_VALUE", "-5")
 
 	isPositive := func(v int) bool { return v > 0 }
 	isLessThan100 := func(v int) bool { return v < 100 }
@@ -126,8 +119,7 @@ func TestGetEnvWithDefault_MultipleValidatorsFirstFails(t *testing.T) {
 
 // TestGetEnvWithDefault_MultipleValidatorsSecondFails tests AND logic (second validator fails)
 func TestGetEnvWithDefault_MultipleValidatorsSecondFails(t *testing.T) {
-	os.Setenv("TEST_VALUE", "150")
-	defer os.Unsetenv("TEST_VALUE")
+	t.Setenv("TEST_VALUE", "150")
 
 	isPositive := func(v int) bool { return v > 0 }
 	isLessThan100 := func(v int) bool { return v < 100 }
@@ -141,8 +133,6 @@ func TestGetEnvWithDefault_MultipleValidatorsSecondFails(t *testing.T) {
 
 // TestGetEnvWithDefault_EmptyEnvDoesNotCallValidator ensures validators aren't called for empty env vars
 func TestGetEnvWithDefault_EmptyEnvDoesNotCallValidator(t *testing.T) {
-	os.Unsetenv("TEST_MISSING")
-
 	validatorCalled := false
 	validator := func(v int) bool {
 		validatorCalled = true
@@ -161,8 +151,7 @@ func TestGetEnvWithDefault_EmptyEnvDoesNotCallValidator(t *testing.T) {
 
 // TestGetEnvWithDefault_ParseFailureDoesNotCallValidator ensures validators aren't called for parse failures
 func TestGetEnvWithDefault_ParseFailureDoesNotCallValidator(t *testing.T) {
-	os.Setenv("TEST_INVALID", "notanumber")
-	defer os.Unsetenv("TEST_INVALID")
+	t.Setenv("TEST_INVALID", "notanumber")
 
 	validatorCalled := false
 	validator := func(v int) bool {
@@ -182,8 +171,7 @@ func TestGetEnvWithDefault_ParseFailureDoesNotCallValidator(t *testing.T) {
 
 // TestGetEnvWithDefault_StringValidation tests validation with string type
 func TestGetEnvWithDefault_StringValidation(t *testing.T) {
-	os.Setenv("TEST_MODE", "production")
-	defer os.Unsetenv("TEST_MODE")
+	t.Setenv("TEST_MODE", "production")
 
 	validModes := func(v string) bool {
 		return v == "development" || v == "staging" || v == "production"
@@ -194,8 +182,7 @@ func TestGetEnvWithDefault_StringValidation(t *testing.T) {
 		t.Errorf("expected production, got %v", result)
 	}
 
-	// Test invalid value
-	os.Setenv("TEST_MODE", "invalid")
+	os.Setenv("TEST_MODE", "invalid") //nolint:errcheck // overriding within t.Setenv-managed scope
 	result = GetEnvWithDefault("TEST_MODE", "development", validModes)
 	if result != "development" {
 		t.Errorf("expected default development, got %v", result)
@@ -204,8 +191,7 @@ func TestGetEnvWithDefault_StringValidation(t *testing.T) {
 
 // TestGetEnvWithDefault_BoolValidation tests validation with bool type
 func TestGetEnvWithDefault_BoolValidation(t *testing.T) {
-	os.Setenv("TEST_ENABLED", "true")
-	defer os.Unsetenv("TEST_ENABLED")
+	t.Setenv("TEST_ENABLED", "true")
 
 	mustBeTrue := func(v bool) bool { return v == true }
 
@@ -214,8 +200,7 @@ func TestGetEnvWithDefault_BoolValidation(t *testing.T) {
 		t.Errorf("expected true, got %v", result)
 	}
 
-	// Test invalid value (false fails validation)
-	os.Setenv("TEST_ENABLED", "false")
+	os.Setenv("TEST_ENABLED", "false") //nolint:errcheck // overriding within t.Setenv-managed scope
 	result = GetEnvWithDefault("TEST_ENABLED", false, mustBeTrue)
 	if result != false {
 		t.Errorf("expected default false, got %v", result)
@@ -224,8 +209,7 @@ func TestGetEnvWithDefault_BoolValidation(t *testing.T) {
 
 // TestGetEnvWithDefault_Float64Validation tests validation with float64 type
 func TestGetEnvWithDefault_Float64Validation(t *testing.T) {
-	os.Setenv("TEST_RATIO", "0.5")
-	defer os.Unsetenv("TEST_RATIO")
+	t.Setenv("TEST_RATIO", "0.5")
 
 	inRange := func(v float64) bool { return v >= 0.0 && v <= 1.0 }
 
@@ -234,8 +218,7 @@ func TestGetEnvWithDefault_Float64Validation(t *testing.T) {
 		t.Errorf("expected 0.5, got %v", result)
 	}
 
-	// Test out of range
-	os.Setenv("TEST_RATIO", "1.5")
+	os.Setenv("TEST_RATIO", "1.5") //nolint:errcheck // overriding within t.Setenv-managed scope
 	result = GetEnvWithDefault("TEST_RATIO", 0.8, inRange)
 	if result != 0.8 {
 		t.Errorf("expected default 0.8, got %v", result)
@@ -244,8 +227,7 @@ func TestGetEnvWithDefault_Float64Validation(t *testing.T) {
 
 // TestGetEnvWithDefault_DurationValidation tests validation with time.Duration type
 func TestGetEnvWithDefault_DurationValidation(t *testing.T) {
-	os.Setenv("TEST_TIMEOUT", "30s")
-	defer os.Unsetenv("TEST_TIMEOUT")
+	t.Setenv("TEST_TIMEOUT", "30s")
 
 	isPositive := func(v time.Duration) bool { return v > 0 }
 	lessThanMinute := func(v time.Duration) bool { return v < time.Minute }
@@ -255,8 +237,7 @@ func TestGetEnvWithDefault_DurationValidation(t *testing.T) {
 		t.Errorf("expected 30s, got %v", result)
 	}
 
-	// Test out of range
-	os.Setenv("TEST_TIMEOUT", "2m")
+	os.Setenv("TEST_TIMEOUT", "2m") //nolint:errcheck // overriding within t.Setenv-managed scope
 	result = GetEnvWithDefault("TEST_TIMEOUT", 10*time.Second, isPositive, lessThanMinute)
 	if result != 10*time.Second {
 		t.Errorf("expected default 10s, got %v", result)

--- a/helpers/getenvwithdefault_test.go
+++ b/helpers/getenvwithdefault_test.go
@@ -30,9 +30,7 @@ func TestGetEnvWithDefault_BackwardCompatibility(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
-				t.Setenv(tt.envVar, tt.envValue)
-			}
+			t.Setenv(tt.envVar, tt.envValue)
 
 			switch expected := tt.expected.(type) {
 			case string:

--- a/helpers/getenvwithdefault_test.go
+++ b/helpers/getenvwithdefault_test.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"os"
 	"testing"
 	"time"
 )
@@ -169,75 +168,87 @@ func TestGetEnvWithDefault_ParseFailureDoesNotCallValidator(t *testing.T) {
 
 // TestGetEnvWithDefault_StringValidation tests validation with string type
 func TestGetEnvWithDefault_StringValidation(t *testing.T) {
-	t.Setenv("TEST_MODE", "production")
-
 	validModes := func(v string) bool {
 		return v == "development" || v == "staging" || v == "production"
 	}
 
-	result := GetEnvWithDefault("TEST_MODE", "development", validModes)
-	if result != "production" {
-		t.Errorf("expected production, got %v", result)
-	}
+	t.Run("valid value", func(t *testing.T) {
+		t.Setenv("TEST_MODE", "production")
+		result := GetEnvWithDefault("TEST_MODE", "development", validModes)
+		if result != "production" {
+			t.Errorf("expected production, got %v", result)
+		}
+	})
 
-	os.Setenv("TEST_MODE", "invalid") //nolint:errcheck // overriding within t.Setenv-managed scope
-	result = GetEnvWithDefault("TEST_MODE", "development", validModes)
-	if result != "development" {
-		t.Errorf("expected default development, got %v", result)
-	}
+	t.Run("invalid value", func(t *testing.T) {
+		t.Setenv("TEST_MODE", "invalid")
+		result := GetEnvWithDefault("TEST_MODE", "development", validModes)
+		if result != "development" {
+			t.Errorf("expected default development, got %v", result)
+		}
+	})
 }
 
 // TestGetEnvWithDefault_BoolValidation tests validation with bool type
 func TestGetEnvWithDefault_BoolValidation(t *testing.T) {
-	t.Setenv("TEST_ENABLED", "true")
+	mustBeTrue := func(v bool) bool { return v }
 
-	mustBeTrue := func(v bool) bool { return v == true }
+	t.Run("valid value", func(t *testing.T) {
+		t.Setenv("TEST_ENABLED", "true")
+		result := GetEnvWithDefault("TEST_ENABLED", false, mustBeTrue)
+		if result != true {
+			t.Errorf("expected true, got %v", result)
+		}
+	})
 
-	result := GetEnvWithDefault("TEST_ENABLED", false, mustBeTrue)
-	if result != true {
-		t.Errorf("expected true, got %v", result)
-	}
-
-	os.Setenv("TEST_ENABLED", "false") //nolint:errcheck // overriding within t.Setenv-managed scope
-	result = GetEnvWithDefault("TEST_ENABLED", false, mustBeTrue)
-	if result != false {
-		t.Errorf("expected default false, got %v", result)
-	}
+	t.Run("invalid value", func(t *testing.T) {
+		t.Setenv("TEST_ENABLED", "false")
+		result := GetEnvWithDefault("TEST_ENABLED", false, mustBeTrue)
+		if result != false {
+			t.Errorf("expected default false, got %v", result)
+		}
+	})
 }
 
 // TestGetEnvWithDefault_Float64Validation tests validation with float64 type
 func TestGetEnvWithDefault_Float64Validation(t *testing.T) {
-	t.Setenv("TEST_RATIO", "0.5")
-
 	inRange := func(v float64) bool { return v >= 0.0 && v <= 1.0 }
 
-	result := GetEnvWithDefault("TEST_RATIO", 0.8, inRange)
-	if result != 0.5 {
-		t.Errorf("expected 0.5, got %v", result)
-	}
+	t.Run("valid value", func(t *testing.T) {
+		t.Setenv("TEST_RATIO", "0.5")
+		result := GetEnvWithDefault("TEST_RATIO", 0.8, inRange)
+		if result != 0.5 {
+			t.Errorf("expected 0.5, got %v", result)
+		}
+	})
 
-	os.Setenv("TEST_RATIO", "1.5") //nolint:errcheck // overriding within t.Setenv-managed scope
-	result = GetEnvWithDefault("TEST_RATIO", 0.8, inRange)
-	if result != 0.8 {
-		t.Errorf("expected default 0.8, got %v", result)
-	}
+	t.Run("invalid value", func(t *testing.T) {
+		t.Setenv("TEST_RATIO", "1.5")
+		result := GetEnvWithDefault("TEST_RATIO", 0.8, inRange)
+		if result != 0.8 {
+			t.Errorf("expected default 0.8, got %v", result)
+		}
+	})
 }
 
 // TestGetEnvWithDefault_DurationValidation tests validation with time.Duration type
 func TestGetEnvWithDefault_DurationValidation(t *testing.T) {
-	t.Setenv("TEST_TIMEOUT", "30s")
-
 	isPositive := func(v time.Duration) bool { return v > 0 }
 	lessThanMinute := func(v time.Duration) bool { return v < time.Minute }
 
-	result := GetEnvWithDefault("TEST_TIMEOUT", 10*time.Second, isPositive, lessThanMinute)
-	if result != 30*time.Second {
-		t.Errorf("expected 30s, got %v", result)
-	}
+	t.Run("valid value", func(t *testing.T) {
+		t.Setenv("TEST_TIMEOUT", "30s")
+		result := GetEnvWithDefault("TEST_TIMEOUT", 10*time.Second, isPositive, lessThanMinute)
+		if result != 30*time.Second {
+			t.Errorf("expected 30s, got %v", result)
+		}
+	})
 
-	os.Setenv("TEST_TIMEOUT", "2m") //nolint:errcheck // overriding within t.Setenv-managed scope
-	result = GetEnvWithDefault("TEST_TIMEOUT", 10*time.Second, isPositive, lessThanMinute)
-	if result != 10*time.Second {
-		t.Errorf("expected default 10s, got %v", result)
-	}
+	t.Run("invalid value", func(t *testing.T) {
+		t.Setenv("TEST_TIMEOUT", "2m")
+		result := GetEnvWithDefault("TEST_TIMEOUT", 10*time.Second, isPositive, lessThanMinute)
+		if result != 10*time.Second {
+			t.Errorf("expected default 10s, got %v", result)
+		}
+	})
 }

--- a/internal/consoleproxy/subresource_test.go
+++ b/internal/consoleproxy/subresource_test.go
@@ -244,7 +244,7 @@ var _ = Describe("forwardUpstreamResponse", func() {
 			}
 
 			rec := httptest.NewRecorder()
-			forwardUpstreamResponse(rec, resp)
+			Expect(forwardUpstreamResponse(rec, resp)).To(Succeed())
 
 			Expect(rec.Code).To(Equal(wantCode))
 			if wantContentType != "" {

--- a/internal/migrations/migrate_subnetrefs_test.go
+++ b/internal/migrations/migrate_subnetrefs_test.go
@@ -86,11 +86,11 @@ var _ = Describe("migrateSubnetRefs", func() {
 			schema.GroupVersionKind{Group: "osac.openshift.io", Version: "v1alpha1", Kind: "ComputeInstanceList"},
 			&unstructured.UnstructuredList{},
 		)
-		os.Setenv(envComputeInstanceNamespace, "default")
+		os.Setenv(envComputeInstanceNamespace, "default") //nolint:errcheck
 	})
 
 	AfterEach(func() {
-		os.Unsetenv(envComputeInstanceNamespace)
+		os.Unsetenv(envComputeInstanceNamespace) //nolint:errcheck
 	})
 
 	It("should migrate a CR with subnetRef to networkAttachments", func() {


### PR DESCRIPTION
## Summary
- Adds validate-manifests CI job with kubeconform v0.6.7 and kube-linter v0.7.1 to check-pull-request workflow
- Adds controller-gen freshness check to CI alongside existing buf-generate check
- Adds kustomize-build and check-generated pre-push hooks for local validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI to render and strictly validate Kubernetes manifests and verify generated code remains unchanged.
  * Added local install target and commands to set up pre-push hooks and install manifest/validation tools.
  * Tightened linter configuration and added kube-linter rules to control check coverage.

* **Documentation**
  * Documented hook installation and updated code-quality guidance.

* **Tests**
  * Improved tests to use safer environment handling and stronger assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->