### PR TITLE
MGMT-24300: fix duplicate AAP jobs from feedback controller race condition

### DIFF
--- a/internal/controller/publicippool_controller.go
+++ b/internal/controller/publicippool_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -129,9 +130,8 @@ func (r *PublicIPPoolReconciler) Reconcile(ctx context.Context, req mcreconcile.
 
 	if !equality.Semantic.DeepEqual(pool.Status, *oldstatus) {
 		log.Info("status requires update")
-		if updateErr := r.Status().Update(ctx, pool); updateErr != nil {
-			log.Error(updateErr, "failed to update status")
-			return res, updateErr
+		if err := r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(pool), pool.Status); err != nil {
+			return res, err
 		}
 	}
 
@@ -241,7 +241,9 @@ func (r *PublicIPPoolReconciler) handleProvisioning(ctx context.Context, pool *v
 			return provisioning.CheckAPIServerForNonTerminalProvisionJob(
 				ctx, r.APIReader, client.ObjectKeyFromObject(pool), &v1alpha1.PublicIPPool{})
 		},
-		func() error { return r.Status().Update(ctx, pool) },
+		func() error {
+			return r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(pool), pool.Status)
+		},
 	)
 }
 
@@ -337,6 +339,18 @@ func (r *PublicIPPoolReconciler) handleDeprovisioning(ctx context.Context, pool 
 		"state", status.State,
 		"message", updatedJob.Message)
 	return ctrl.Result{}, nil
+}
+
+// updateStatusWithRetry updates the public IP pool status with retry on conflict.
+func (r *PublicIPPoolReconciler) updateStatusWithRetry(ctx context.Context, key client.ObjectKey, newStatus v1alpha1.PublicIPPoolStatus) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &v1alpha1.PublicIPPool{}
+		if err := r.Get(ctx, key, latest); err != nil {
+			return err
+		}
+		latest.Status = newStatus
+		return r.Status().Update(ctx, latest)
+	})
 }
 
 // SetupWithManager registers this controller with the multicluster manager.

--- a/internal/controller/publicippool_controller_test.go
+++ b/internal/controller/publicippool_controller_test.go
@@ -140,6 +140,41 @@ var _ = Describe("PublicIPPoolReconciler", func() {
 			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPPoolPhaseProgressing))
 		})
 
+		It("should persist job status even when resource is concurrently modified", func() {
+			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+
+			// Simulate feedback controller: during TriggerProvision, modify
+			// the resource's metadata (add feedback finalizer) so the
+			// resourceVersion changes before the status flush runs.
+			// Set mock before any reconcile because PublicIPPool triggers
+			// provisioning in the same pass as adding the finalizer.
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				fresh := &osacv1alpha1.PublicIPPool{}
+				Expect(fakeClient.Get(ctx, key, fresh)).To(Succeed())
+				fresh.Finalizers = append(fresh.Finalizers, "osac.openshift.io/publicippool-feedback")
+				Expect(fakeClient.Update(ctx, fresh)).To(Succeed())
+
+				return &provisioning.ProvisionResult{
+					JobID:        "concurrent-job-123",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Provisioning triggered",
+				}, nil
+			}
+
+			// Reconcile adds finalizer and triggers provisioning in one pass.
+			// The concurrent modification must not prevent the job from
+			// being recorded in status.
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the job was persisted
+			updated := &osacv1alpha1.PublicIPPool{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			latestJob := provisioning.FindLatestJobByType(updated.Status.Jobs, osacv1alpha1.JobTypeProvision)
+			Expect(latestJob).NotTo(BeNil())
+			Expect(latestJob.JobID).To(Equal("concurrent-job-123"))
+		})
+
 		It("should set ConfigurationApplied condition to True", func() {
 			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
 

--- a/internal/controller/securitygroup_controller.go
+++ b/internal/controller/securitygroup_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -115,9 +116,8 @@ func (r *SecurityGroupReconciler) Reconcile(ctx context.Context, req mcreconcile
 
 	if !equality.Semantic.DeepEqual(sg.Status, *oldstatus) {
 		log.Info("status requires update")
-		if updateErr := r.Status().Update(ctx, sg); updateErr != nil {
-			log.Error(updateErr, "failed to update status")
-			return res, updateErr
+		if err := r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(sg), sg.Status); err != nil {
+			return res, err
 		}
 	}
 
@@ -245,7 +245,9 @@ func (r *SecurityGroupReconciler) handleProvisioning(ctx context.Context, sg *v1
 		func() bool {
 			return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, r.APIReader, client.ObjectKeyFromObject(sg), &v1alpha1.SecurityGroup{})
 		},
-		func() error { return r.Status().Update(ctx, sg) },
+		func() error {
+			return r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(sg), sg.Status)
+		},
 	)
 }
 
@@ -340,6 +342,18 @@ func (r *SecurityGroupReconciler) handleDeprovisioning(ctx context.Context, sg *
 		"state", status.State,
 		"message", updatedJob.Message)
 	return ctrl.Result{}, nil
+}
+
+// updateStatusWithRetry updates the security group status with retry on conflict.
+func (r *SecurityGroupReconciler) updateStatusWithRetry(ctx context.Context, key client.ObjectKey, newStatus v1alpha1.SecurityGroupStatus) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &v1alpha1.SecurityGroup{}
+		if err := r.Get(ctx, key, latest); err != nil {
+			return err
+		}
+		latest.Status = newStatus
+		return r.Status().Update(ctx, latest)
+	})
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/securitygroup_controller_test.go
+++ b/internal/controller/securitygroup_controller_test.go
@@ -163,6 +163,42 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.SecurityGroupPhaseProgressing))
 		})
 
+		It("should persist job status even when resource is concurrently modified", func() {
+			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
+
+			// First reconcile: adds finalizer + sets annotation, returns early
+			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Simulate feedback controller: during TriggerProvision, modify
+			// the resource's metadata (add feedback finalizer) so the
+			// resourceVersion changes before the status flush runs.
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				fresh := &osacv1alpha1.SecurityGroup{}
+				Expect(fakeClient.Get(ctx, key, fresh)).To(Succeed())
+				fresh.Finalizers = append(fresh.Finalizers, "osac.openshift.io/securitygroup-feedback")
+				Expect(fakeClient.Update(ctx, fresh)).To(Succeed())
+
+				return &provisioning.ProvisionResult{
+					JobID:        "concurrent-job-123",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Provisioning triggered",
+				}, nil
+			}
+
+			// Second reconcile: triggers job — the concurrent modification
+			// must not prevent the job from being recorded in status.
+			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the job was persisted
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
+			latestJob := provisioning.FindLatestJobByType(updated.Status.Jobs, osacv1alpha1.JobTypeProvision)
+			Expect(latestJob).NotTo(BeNil())
+			Expect(latestJob.JobID).To(Equal("concurrent-job-123"))
+		})
+
 		It("should lookup parent VirtualNetwork", func() {
 			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
 

--- a/internal/controller/subnet_controller.go
+++ b/internal/controller/subnet_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -122,13 +123,25 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req mcreconcile.Reques
 
 	if !equality.Semantic.DeepEqual(subnet.Status, *oldstatus) {
 		log.Info("status requires update")
-		if err := r.Status().Update(ctx, subnet); err != nil {
+		if err := r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(subnet), subnet.Status); err != nil {
 			return res, err
 		}
 	}
 
 	log.Info("end reconcile")
 	return res, err
+}
+
+// updateStatusWithRetry updates the subnet status with retry on conflict.
+func (r *SubnetReconciler) updateStatusWithRetry(ctx context.Context, key client.ObjectKey, newStatus v1alpha1.SubnetStatus) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &v1alpha1.Subnet{}
+		if err := r.Get(ctx, key, latest); err != nil {
+			return err
+		}
+		latest.Status = newStatus
+		return r.Status().Update(ctx, latest)
+	})
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -265,7 +278,9 @@ func (r *SubnetReconciler) handleProvisioning(ctx context.Context, subnet *v1alp
 		func() bool {
 			return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, r.APIReader, client.ObjectKeyFromObject(subnet), &v1alpha1.Subnet{})
 		},
-		func() error { return r.Status().Update(ctx, subnet) },
+		func() error {
+			return r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(subnet), subnet.Status)
+		},
 	)
 }
 

--- a/internal/controller/subnet_controller_test.go
+++ b/internal/controller/subnet_controller_test.go
@@ -148,6 +148,49 @@ var _ = Describe("SubnetReconciler", func() {
 			Expect(updatedSubnet.Status.Phase).To(Equal(osacv1alpha1.SubnetPhaseProgressing))
 		})
 
+		It("should persist job status even when resource is concurrently modified", func() {
+			Expect(k8sClient.Create(ctx, subnet)).To(Succeed())
+
+			req := mcreconcile.Request{Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      subnet.Name,
+					Namespace: subnet.Namespace,
+				},
+			}}
+
+			// First reconcile: adds finalizer + sets annotation, returns early
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Simulate feedback controller: during TriggerProvision, modify
+			// the resource's metadata (add feedback finalizer) so the
+			// resourceVersion changes before the status flush runs.
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				fresh := &osacv1alpha1.Subnet{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: subnet.Name, Namespace: subnet.Namespace}, fresh)).To(Succeed())
+				fresh.Finalizers = append(fresh.Finalizers, "osac.openshift.io/subnet-feedback")
+				Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+
+				return &provisioning.ProvisionResult{
+					JobID:        "concurrent-job-123",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Provisioning triggered",
+				}, nil
+			}
+
+			// Second reconcile: triggers job — the concurrent modification
+			// must not prevent the job from being recorded in status.
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the job was persisted to the API server
+			updatedSubnet := &osacv1alpha1.Subnet{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: subnet.Name, Namespace: subnet.Namespace}, updatedSubnet)).To(Succeed())
+			latestJob := provisioning.FindLatestJobByType(updatedSubnet.Status.Jobs, osacv1alpha1.JobTypeProvision)
+			Expect(latestJob).NotTo(BeNil())
+			Expect(latestJob.JobID).To(Equal("concurrent-job-123"))
+		})
+
 		It("should requeue when parent VirtualNetwork not found", func() {
 			// Create subnet with non-existent parent
 			subnetNoParent := &osacv1alpha1.Subnet{

--- a/internal/controller/virtualnetwork_controller.go
+++ b/internal/controller/virtualnetwork_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -115,7 +116,7 @@ func (r *VirtualNetworkReconciler) Reconcile(ctx context.Context, req mcreconcil
 
 	if !equality.Semantic.DeepEqual(vnet.Status, *oldstatus) {
 		log.Info("status requires update")
-		if err := r.Status().Update(ctx, vnet); err != nil {
+		if err := r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(vnet), vnet.Status); err != nil {
 			return res, err
 		}
 	}
@@ -199,7 +200,9 @@ func (r *VirtualNetworkReconciler) handleProvisioning(ctx context.Context, vnet 
 		func() bool {
 			return provisioning.CheckAPIServerForNonTerminalProvisionJob(ctx, r.APIReader, client.ObjectKeyFromObject(vnet), &v1alpha1.VirtualNetwork{})
 		},
-		func() error { return r.Status().Update(ctx, vnet) },
+		func() error {
+			return r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(vnet), vnet.Status)
+		},
 	)
 }
 
@@ -324,6 +327,18 @@ func (r *VirtualNetworkReconciler) handleDeprovisioning(ctx context.Context, vne
 			"message", updatedJob.Message)
 		return ctrl.Result{}, nil
 	}
+}
+
+// updateStatusWithRetry updates the virtual network status with retry on conflict.
+func (r *VirtualNetworkReconciler) updateStatusWithRetry(ctx context.Context, key client.ObjectKey, newStatus v1alpha1.VirtualNetworkStatus) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &v1alpha1.VirtualNetwork{}
+		if err := r.Get(ctx, key, latest); err != nil {
+			return err
+		}
+		latest.Status = newStatus
+		return r.Status().Update(ctx, latest)
+	})
 }
 
 // NetworkingNamespacePredicate filters events by namespace for networking resources.

--- a/internal/controller/virtualnetwork_controller_test.go
+++ b/internal/controller/virtualnetwork_controller_test.go
@@ -164,6 +164,49 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 			Expect(latestJob.JobID).To(Equal("test-job-123"))
 		})
 
+		It("should persist job status even when resource is concurrently modified", func() {
+			Expect(k8sClient.Create(ctx, vnet)).To(Succeed())
+
+			req := mcreconcile.Request{Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vnet.Name,
+					Namespace: vnet.Namespace,
+				},
+			}}
+
+			// First reconcile: adds finalizer + sets annotation, returns early
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Simulate feedback controller: during TriggerProvision, modify
+			// the resource's metadata (add feedback finalizer) so the
+			// resourceVersion changes before the status flush runs.
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				fresh := &osacv1alpha1.VirtualNetwork{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vnet.Name, Namespace: vnet.Namespace}, fresh)).To(Succeed())
+				fresh.Finalizers = append(fresh.Finalizers, "osac.openshift.io/virtualnetwork-feedback")
+				Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+
+				return &provisioning.ProvisionResult{
+					JobID:        "concurrent-job-123",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Provisioning triggered",
+				}, nil
+			}
+
+			// Second reconcile: triggers job — the concurrent modification
+			// must not prevent the job from being recorded in status.
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the job was persisted to the API server
+			updatedVnet := &osacv1alpha1.VirtualNetwork{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vnet.Name, Namespace: vnet.Namespace}, updatedVnet)).To(Succeed())
+			latestJob := provisioning.FindLatestJobByType(updatedVnet.Status.Jobs, osacv1alpha1.JobTypeProvision)
+			Expect(latestJob).NotTo(BeNil())
+			Expect(latestJob.JobID).To(Equal("concurrent-job-123"))
+		})
+
 		It("should requeue if ImplementationStrategy not set", func() {
 			// Create VirtualNetwork without ImplementationStrategy
 			vnetNoStrategy := &osacv1alpha1.VirtualNetwork{


### PR DESCRIPTION
The feedback controller adds its finalizer concurrently with the resource controller's reconcile, changing the resourceVersion. When the resource controller tries to flush status after triggering an AAP job, it gets a conflict error and the job is never recorded. The next reconcile sees no job and triggers a duplicate.

Fix by re-reading the resource from the API server via APIReader.Get() before status updates to get the latest resourceVersion. Applied to all 4 networking controllers (VirtualNetwork, Subnet, SecurityGroup, PublicIPPool) in both the statusFlush callback and the end-of-reconcile status update. Added concurrent-modification tests for all controllers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of status updates across cloud resource controllers by implementing conflict-aware retry mechanisms. Status changes now persist reliably even when resources are concurrently modified, preventing loss of provisioning job information.

* **Tests**
  * Added test coverage verifying status persistence for PublicIPPool, SecurityGroup, Subnet, and VirtualNetwork resources during concurrent resource modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->