### PR TITLE
OSAC-477: Add netris as valid implementation strategy for PublicIPPool

### DIFF
--- a/api/v1alpha1/publicippool_types.go
+++ b/api/v1alpha1/publicippool_types.go
@@ -37,7 +37,7 @@ type PublicIPPoolSpec struct {
 	// Defaults to metallb-l2 for v7.0.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Enum=metallb-l2
+	// +kubebuilder:validation:Enum=metallb-l2;netris
 	ImplementationStrategy string `json:"implementationStrategy,omitempty"`
 }
 

--- a/api/v1alpha1/publicippool_types_test.go
+++ b/api/v1alpha1/publicippool_types_test.go
@@ -21,6 +21,16 @@ var _ = Describe("PublicIPPoolSpec", func() {
 		Expect(spec.ImplementationStrategy).To(Equal("metallb-l2"))
 	})
 
+	It("should accept netris as a valid implementation strategy", func() {
+		spec := v1alpha1.PublicIPPoolSpec{
+			CIDRs:                  []string{"192.168.1.0/24"},
+			IPFamily:               "IPv4",
+			ImplementationStrategy: "netris",
+		}
+
+		Expect(spec.ImplementationStrategy).To(Equal("netris"))
+	})
+
 	It("should accept a minimal spec without optional fields", func() {
 		spec := v1alpha1.PublicIPPoolSpec{
 			CIDRs:    []string{"10.0.0.0/16"},

--- a/config/crd/bases/osac.openshift.io_publicippools.yaml
+++ b/config/crd/bases/osac.openshift.io_publicippools.yaml
@@ -70,6 +70,7 @@ spec:
                   Defaults to metallb-l2 for v7.0.
                 enum:
                 - metallb-l2
+                - netris
                 type: string
               ipFamily:
                 description: IPFamily indicates the IP address family for this pool


### PR DESCRIPTION
Allow `PublicIPPool` resources to use `netris` as an implementation strategy alongside the existing `metallb-l2` backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public IP Pools now allow "netris" as an implementation strategy in addition to "metallb-l2", enabling selection of an additional backend for public IP management.

* **Tests**
  * Added a unit test confirming "netris" is accepted as a valid implementation strategy to ensure schema and validation behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->