### PR TITLE
OSAC-687: Inject resolved storageClasses into AAP extra_vars

### DIFF
--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -703,6 +703,11 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 		}
 	}
 
+	// Inject tenant storage classes into context for AAP extra_vars
+	if len(tenant.Status.StorageClasses) > 0 {
+		ctx = provisioning.WithTenantStorageClasses(ctx, tenant.Status.StorageClasses)
+	}
+
 	// Always delegate to provisioning lifecycle — EvaluateAction decides
 	// whether to skip, poll, or trigger. This avoids the A-B-A problem where
 	// IsConfigApplied alone could match a stale historical job.

--- a/pkg/provisioning/aap_provider.go
+++ b/pkg/provisioning/aap_provider.go
@@ -338,7 +338,7 @@ func (p *AAPProvider) launchTemplate(ctx context.Context, templateName string, r
 		return "", fmt.Errorf("failed to get template: %w", err)
 	}
 
-	extraVars, err := extractExtraVars(resource)
+	extraVars, err := extractExtraVars(ctx, resource)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract extra vars: %w", err)
 	}
@@ -440,19 +440,30 @@ func mapAAPStatusToJobState(aapStatus string) v1alpha1.JobState {
 //
 // Future improvement: When/if we migrate away from EDA-triggered templates, this wrapper can be
 // removed and parameters can be passed directly as flat key-value pairs.
-func extractExtraVars(resource client.Object) (map[string]any, error) {
+func extractExtraVars(ctx context.Context, resource client.Object) (map[string]any, error) {
 	// Convert the resource to map using JSON marshaling (respects JSON tags)
 	resourceMap, err := serializeResource(resource)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize resource: %w", err)
 	}
 
-	// Wrap the full resource in EDA event structure for compatibility with EDA-designed templates
+	event := map[string]any{
+		"payload": resourceMap,
+	}
+
+	// Inject tenant storage classes if present in context (set by CI controller)
+	if scs := TenantStorageClassesFromContext(ctx); len(scs) > 0 {
+		scList := make([]map[string]string, len(scs))
+		for i, sc := range scs {
+			scList[i] = map[string]string{"name": sc.Name, "tier": sc.Tier}
+		}
+		event["tenant_storage_classes"] = scList
+	}
+
+	// Wrap in EDA event structure for compatibility with EDA-designed templates
 	return map[string]any{
 		"ansible_eda": map[string]any{
-			"event": map[string]any{
-				"payload": resourceMap,
-			},
+			"event": event,
 		},
 	}, nil
 }

--- a/pkg/provisioning/aap_provider_test.go
+++ b/pkg/provisioning/aap_provider_test.go
@@ -158,6 +158,62 @@ var _ = Describe("AAPProvider", func() {
 			})
 		})
 
+		Context("with tenant storage classes in context", func() {
+			BeforeEach(func() {
+				provider = provisioning.NewAAPProvider(aapClient, "provision-job", "deprovision-job")
+				aapClient.getTemplateFunc = func(ctx context.Context, templateName string) (*aap.Template, error) {
+					return &aap.Template{ID: 1, Name: templateName, Type: aap.TemplateTypeJob}, nil
+				}
+			})
+
+			It("should inject tenant_storage_classes into extra_vars", func() {
+				aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
+					edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
+					Expect(edaEvent).To(HaveKey("payload"))
+					Expect(edaEvent).To(HaveKey("tenant_storage_classes"))
+					scList := edaEvent["tenant_storage_classes"].([]map[string]string)
+					Expect(scList).To(HaveLen(2))
+					Expect(scList[0]).To(Equal(map[string]string{"name": "ceph-fast", "tier": "fast"}))
+					Expect(scList[1]).To(Equal(map[string]string{"name": "ceph-default", "tier": "default"}))
+					return &aap.LaunchJobTemplateResponse{JobID: 789}, nil
+				}
+
+				ctx = provisioning.WithTenantStorageClasses(ctx, []v1alpha1.ResolvedStorageClass{
+					{Name: "ceph-fast", Tier: "fast"},
+					{Name: "ceph-default", Tier: "default"},
+				})
+
+				instance := &v1alpha1.ComputeInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-resource",
+						Namespace: "default",
+					},
+				}
+				result, err := provider.TriggerProvision(ctx, instance)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.JobID).To(Equal("789"))
+			})
+
+			It("should not inject tenant_storage_classes when context has no storage classes", func() {
+				aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
+					edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
+					Expect(edaEvent).To(HaveKey("payload"))
+					Expect(edaEvent).NotTo(HaveKey("tenant_storage_classes"))
+					return &aap.LaunchJobTemplateResponse{JobID: 790}, nil
+				}
+
+				instance := &v1alpha1.ComputeInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-resource",
+						Namespace: "default",
+					},
+				}
+				result, err := provider.TriggerProvision(ctx, instance)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.JobID).To(Equal("790"))
+			})
+		})
+
 		Context("when template not configured", func() {
 			BeforeEach(func() {
 				provider = provisioning.NewAAPProvider(aapClient, "", "deprovision-job")

--- a/pkg/provisioning/extra_vars_context.go
+++ b/pkg/provisioning/extra_vars_context.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"context"
+
+	v1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
+)
+
+type contextKey int
+
+const tenantStorageClassesKey contextKey = iota
+
+// WithTenantStorageClasses returns a context carrying the tenant's resolved
+// storage classes. The AAP provider reads this when building extra_vars.
+func WithTenantStorageClasses(ctx context.Context, scs []v1alpha1.ResolvedStorageClass) context.Context {
+	return context.WithValue(ctx, tenantStorageClassesKey, scs)
+}
+
+// TenantStorageClassesFromContext retrieves the tenant storage classes from the
+// context, or nil if not set.
+func TenantStorageClassesFromContext(ctx context.Context) []v1alpha1.ResolvedStorageClass {
+	scs, _ := ctx.Value(tenantStorageClassesKey).([]v1alpha1.ResolvedStorageClass)
+	return scs
+}


### PR DESCRIPTION
## Summary

- Pass the tenant's resolved `storageClasses` list to AAP via extra_vars so that the `tenant_storage_class` Ansible role can resolve storage tiers without querying the K8s API
- CI controller stores `tenant.Status.StorageClasses` in Go context after fetching the Tenant CR
- AAP provider reads it when building extra_vars and adds it as `ansible_eda.event.tenant_storage_classes`
- Uses context values to avoid changing the `ProvisioningProvider` interface, which is shared across all resource types

Per the [Tenant Storage Tiers](https://github.com/osac-project/enhancement-proposals/blob/main/enhancements/tenant-storage-tiers/README.md) enhancement proposal: the CI controller already fetches the Tenant CR to verify readiness; it reads `tenant.status.storageClasses` at that point and injects the list alongside the ComputeInstance payload.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/provisioning/` passes — positive and negative path tests for extra_vars injection
- [x] `go test ./internal/controller/` passes

Jira: [OSAC-687](https://redhat.atlassian.net/browse/OSAC-687)

**Companion PR:** [osac-aap#291](https://github.com/osac-project/osac-aap/pull/291) (OSAC-175, [OSAC-176](https://redhat.atlassian.net/browse/OSAC-176)) updates the Ansible role and playbook to consume `tenant_storage_classes` from extra_vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant storage classes are now automatically provided to the provisioning system during resource provisioning operations.

* **Tests**
  * Added test coverage for tenant storage class injection in provisioning workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/229)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->