### PR TITLE
OSAC-744: stop syncing capacity from CR to fulfillment-service

### DIFF
--- a/internal/controller/publicippool_feedback_controller.go
+++ b/internal/controller/publicippool_feedback_controller.go
@@ -242,7 +242,6 @@ func (t *publicIPPoolFeedbackReconcilerTask) handleUpdate(ctx context.Context) e
 		}
 	}
 	t.syncPhase(ctx)
-	t.syncCapacity()
 	return nil
 }
 
@@ -293,14 +292,4 @@ func (t *publicIPPoolFeedbackReconcilerTask) syncPhaseReady() {
 
 func (t *publicIPPoolFeedbackReconcilerTask) syncPhaseDeleting() {
 	t.publicIPPool.GetStatus().SetState(privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_DELETING)
-}
-
-// syncCapacity copies the capacity fields (total, allocated, available) from the CR status to the proto status.
-// Unlike SecurityGroup/Subnet/VirtualNetwork, PublicIPPool tracks address space usage. The fulfillment service uses
-// these numbers to report pool utilization and enforce allocation limits.
-func (t *publicIPPoolFeedbackReconcilerTask) syncCapacity() {
-	poolStatus := t.publicIPPool.GetStatus()
-	poolStatus.SetTotal(t.object.Status.Total)
-	poolStatus.SetAllocated(t.object.Status.Allocated)
-	poolStatus.SetAvailable(t.object.Status.Available)
 }

--- a/internal/controller/publicippool_feedback_controller_test.go
+++ b/internal/controller/publicippool_feedback_controller_test.go
@@ -98,7 +98,7 @@ var _ = Describe("PublicIPPoolFeedbackController", func() {
 	})
 
 	Context("when reconciling a PublicIPPool CR", func() {
-		It("should sync Phase=Ready to database state=READY with capacity fields", func() {
+		It("should sync Phase=Ready to database state=READY", func() {
 			pool := &privatev1.PublicIPPool{
 				Id: poolID,
 				Metadata: &privatev1.Metadata{
@@ -124,10 +124,7 @@ var _ = Describe("PublicIPPoolFeedbackController", func() {
 					IPFamily: "IPv4",
 				},
 				Status: v1alpha1.PublicIPPoolStatus{
-					Phase:     v1alpha1.PublicIPPoolPhaseReady,
-					Total:     254,
-					Allocated: 10,
-					Available: 244,
+					Phase: v1alpha1.PublicIPPoolPhaseReady,
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
@@ -140,18 +137,65 @@ var _ = Describe("PublicIPPoolFeedbackController", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Assert gRPC Update called with state=READY and capacity fields
+			// Assert gRPC Update called with state=READY
+			Expect(mockServer.updates).To(HaveLen(1))
+			updated := mockServer.updates[0]
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY))
+
+			// Assert finalizer was added
+			fetched := &v1alpha1.PublicIPPool{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: poolNamespace}, fetched)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(fetched, osacPublicIPPoolFeedbackFinalizer)).To(BeTrue())
+		})
+
+		It("should preserve existing capacity when syncing phase", func() {
+			pool := &privatev1.PublicIPPool{
+				Id: poolID,
+				Metadata: &privatev1.Metadata{
+					Name: poolName,
+				},
+				Spec: &privatev1.PublicIPPoolSpec{},
+				Status: &privatev1.PublicIPPoolStatus{
+					State:     privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_PENDING,
+					Total:     254,
+					Allocated: 10,
+					Available: 244,
+				},
+			}
+			mockServer.addPublicIPPool(pool)
+
+			cr := &v1alpha1.PublicIPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: poolNamespace,
+					Labels: map[string]string{
+						osacPublicIPPoolIDLabel: poolID,
+					},
+				},
+				Spec: v1alpha1.PublicIPPoolSpec{
+					CIDRs:    []string{"10.0.0.0/24"},
+					IPFamily: "IPv4",
+				},
+				Status: v1alpha1.PublicIPPoolStatus{
+					Phase: v1alpha1.PublicIPPoolPhaseReady,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      poolName,
+					Namespace: poolNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
 			Expect(mockServer.updates).To(HaveLen(1))
 			updated := mockServer.updates[0]
 			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY))
 			Expect(updated.GetStatus().GetTotal()).To(Equal(int64(254)))
 			Expect(updated.GetStatus().GetAllocated()).To(Equal(int64(10)))
 			Expect(updated.GetStatus().GetAvailable()).To(Equal(int64(244)))
-
-			// Assert finalizer was added
-			fetched := &v1alpha1.PublicIPPool{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: poolNamespace}, fetched)).To(Succeed())
-			Expect(controllerutil.ContainsFinalizer(fetched, osacPublicIPPoolFeedbackFinalizer)).To(BeTrue())
 		})
 
 		It("should sync Phase=Progressing to database state=PENDING", func() {
@@ -532,10 +576,7 @@ var _ = Describe("PublicIPPoolFeedbackController", func() {
 					IPFamily: "IPv4",
 				},
 				Status: v1alpha1.PublicIPPoolStatus{
-					Phase:     v1alpha1.PublicIPPoolPhaseReady,
-					Total:     254,
-					Allocated: 10,
-					Available: 244,
+					Phase: v1alpha1.PublicIPPoolPhaseReady,
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
@@ -548,7 +589,7 @@ var _ = Describe("PublicIPPoolFeedbackController", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Assert no Update RPC was called (state already READY with matching capacity, finalizer pre-seeded)
+			// Assert no Update RPC was called (state already READY, finalizer pre-seeded)
 			Expect(mockServer.updates).To(BeEmpty())
 		})
 	})


### PR DESCRIPTION
## Summary

[OSAC-744](https://redhat.atlassian.net/browse/OSAC-744): Fix PublicIPPool capacity resetting to 0 after feedback controller syncs state back to the fulfillment-service.

## Why

The PublicIPPool feedback controller was copying capacity fields (Total, Allocated, Available) from the CR status to the fulfillment-service via gRPC Update without a field mask. The operator never populates these CR fields, so they are always zero. The full-object replacement overwrites the real capacity that the fulfillment-service manages (calculated at pool creation from CIDRs, updated atomically on IP allocate/release).

After any feedback reconcile, the pool's capacity dropped to 0, preventing further PublicIP allocations.

## Testing

### Unit tests

```bash
make lint
# 0 issues.

make test
# ok github.com/osac-project/osac-operator/internal/controller 12.646s coverage: 64.0%
```

Updated tests:
- Removed capacity sync assertions from phase sync test
- Added "should preserve existing capacity when syncing phase" test: DB proto starts with Total=254/Allocated=10/Available=244, CR has zero capacity, reconcile preserves DB values
- Updated "should not update if status unchanged" test to remove CR capacity fields

### E2E verification on edge22

Deployed `quay.io/rh-ee-anadkarn/osac-operator:260508-1026` (commit `3cdd9f9`) to edge22.

**Test 1: New pool capacity preserved after feedback reconcile**

1. Created `verify-pool` via private API with CIDR `192.168.127.240/29`
2. Fulfillment-service calculated capacity: Total=6, Available=6
3. Operator provisioned pool (AAP job 13129 succeeded), CR transitioned to Ready
4. CR status has Total=0, Available=0 (operator does not populate capacity)
5. Feedback controller synced Ready state back to fulfillment-service
6. **Result: PASS** - capacity preserved at Total=6, Available=6

```
grpcurl ... osac.private.v1.PublicIPPools/Get
  "status": { "state": "PUBLIC_IP_POOL_STATE_READY", "total": "6", "available": "6" }
```

**Test 2: Existing pool capacity preserved after operator restart**

1. Existing `demo-pool` had Total=6, Allocated=1, Available=5 before deploying the fix
2. After operator restart with the fix, feedback controller reconciled the pool
3. **Result: PASS** - capacity unchanged at Total=6, Allocated=1, Available=5

## Ticket

[OSAC-744](https://redhat.atlassian.net/browse/OSAC-744)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>