### PR TITLE
Fix status.address not populated on PublicIP allocation success

### DIFF
--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -877,14 +877,23 @@ func (r *PublicIPReconciler) handleProvisioning(ctx context.Context, publicIP *v
 					// so the address population guard in handleUpdate never fires.
 					// Populate address here to cover that path.
 					if publicIP.Status.Address == "" {
-						if targetClient, err := getTargetClient(ctx, r.mgr, r.targetCluster); err == nil {
-							if ip := r.getPublicIPAddress(ctx, targetClient, publicIP.Name); ip != "" {
-								publicIP.Status.Address = ip
-							}
+						if targetClient, err := getTargetClient(ctx, r.mgr, r.targetCluster); err != nil {
+							log.Error(err, "failed to get target cluster client for address lookup on attach")
+						} else if ip := r.getPublicIPAddress(ctx, targetClient, publicIP.Name); ip != "" {
+							publicIP.Status.Address = ip
 						}
 					}
 				} else {
 					publicIP.Status.State = v1alpha1.PublicIPStateAllocated
+					// Populate address immediately on allocation success. For detach, address is
+					// usually already set so the guard no-ops.
+					if publicIP.Status.Address == "" {
+						if targetClient, err := getTargetClient(ctx, r.mgr, r.targetCluster); err != nil {
+							log.Error(err, "failed to get target cluster client for address lookup on allocation")
+						} else if ip := r.getPublicIPAddress(ctx, targetClient, publicIP.Name); ip != "" {
+							publicIP.Status.Address = ip
+						}
+					}
 					// After detach completes, attempt CI finalizer removal
 					if priorCIUUID != "" {
 						if err := r.maybeRemoveCIFinalizer(ctx, priorCIUUID, ""); err != nil {

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -592,6 +592,59 @@ var _ = Describe("PublicIPReconciler", func() {
 			Expect(updated.Status.State).To(Equal(osacv1alpha1.PublicIPStateAllocated))
 		})
 
+		It("should populate address in OnSuccess on initial allocation when Service already has an IP", func() {
+			// This test covers the new code path added to the OnSuccess callback inside
+			// handleProvisioning: when state transitions to Allocated and the parking
+			// Service already has an ingress IP, the address must be set immediately
+			// within the same reconcile pass — no extra round-trip through handleUpdate.
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
+
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      publicIPServiceNamePrefix + publicIP.Name,
+					Namespace: defaultMetalLBNamespace,
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.10"}},
+					},
+				},
+			}
+			targetClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(svc).Build()
+			reconciler.mgr = &mockMulticlusterManager{targetClient: targetClient}
+
+			mockProvider.triggerProvisionFunc = func(
+				_ context.Context, _ client.Object,
+			) (*provisioning.ProvisionResult, error) {
+				return &provisioning.ProvisionResult{
+					JobID:        "job-alloc-addr",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Job triggered",
+				}, nil
+			}
+			mockProvider.getProvisionStatusFunc = func(
+				_ context.Context, _ client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID:   jobID,
+					State:   osacv1alpha1.JobStateSucceeded,
+					Message: "Provisioning completed",
+				}, nil
+			}
+
+			// Pass 1: finalizer, Pass 2: trigger job, Pass 3: poll -> Succeeded -> OnSuccess
+			for i := 0; i < 3; i++ {
+				_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			updated := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Status.State).To(Equal(osacv1alpha1.PublicIPStateAllocated))
+			Expect(updated.Status.Address).To(Equal("203.0.113.10"),
+				"address should be populated immediately in OnSuccess, not deferred to the next reconcile")
+		})
+
 		It("should set state to Attaching when ComputeInstance is set on allocated IP", func() {
 			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 


### PR DESCRIPTION
### Problem
After a create_public_ip job succeeds, status.address was never set on the PublicIP CR, leaving it permanently empty.

./osac get publicip
ID                                    NAME  POOL                                  STATE      ADDRESS  HUB  COMPUTE-INSTANCE
019e0879-e116-7b2c-8078-17e8d1e19b2b  mp    019dfd63-044e-7400-b353-541a809fa401  ALLOCATED  -        hub  -

### Root cause
maybePopulateAddress is called in handleUpdate before routeProvisioning. On the pass where OnSuccess fires, maybePopulateAddress sees state=Pending (not yet Allocated) and exits via its guard — a no-op. By the time OnSuccess sets state=Allocated, maybePopulateAddress has already returned.

### Fix
Move address population into OnSuccess for the allocation path, making it atomic with the state=Allocated transition. The create_public_ip playbook already waits for MetalLB IP assignment before the job reports success, so the address is always available at this point.

### Tests Addes
Check  populate address in OnSuccess on initial allocation when Service already has an IP — verifies address is set in the same reconcile pass as OnSuccess

### E2E Verification
 ./osac get publicip
ID                                    NAME  POOL                                  STATE      ADDRESS       HUB  COMPUTE-INSTANCE
019e0882-1324-73b4-b2bd-b6427dabd9d7  mp1   019dfd63-044e-7400-b353-541a809fa401  ALLOCATED  192.168.99.3  hub  -

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoadBalancer address population reliability during public IP allocation with enhanced error handling and logging.

* **Tests**
  * Added test coverage for address population behavior during initial allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->