### PR TITLE
OSAC-776: preserve target-namespace annotation during PublicIP detach

### DIFF
--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -329,9 +329,12 @@ func (r *PublicIPReconciler) syncComputeInstanceTargetNamespaceAnnotation(
 
 	if publicIP.Spec.ComputeInstance == "" {
 		if _, ok := publicIP.Annotations[osacPublicIPTargetNamespaceAnnotation]; ok {
-			delete(publicIP.Annotations, osacPublicIPTargetNamespaceAnnotation)
-			log.Info("cleared publicip-target-namespace annotation")
-			return true, false, nil
+			if publicIP.Status.State != v1alpha1.PublicIPStateReleasing {
+				delete(publicIP.Annotations, osacPublicIPTargetNamespaceAnnotation)
+				log.Info("cleared publicip-target-namespace annotation")
+				return true, false, nil
+			}
+			log.Info("preserving publicip-target-namespace annotation during detach")
 		}
 		return false, false, nil
 	}

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -1295,6 +1295,46 @@ var _ = Describe("PublicIPReconciler", func() {
 			Expect(exists).To(BeFalse())
 		})
 
+		It("should preserve publicip-target-namespace annotation during detach", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-releasing",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						osacPublicIPTargetNamespaceAnnotation: testTenantNS,
+					},
+					Finalizers: []string{osacPublicIPFinalizer},
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool: testPoolUUID,
+				},
+			}
+
+			fc := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(pip, parentPool).
+				WithStatusSubresource(&osacv1alpha1.PublicIP{}).
+				Build()
+
+			pip.Status.State = osacv1alpha1.PublicIPStateReleasing
+			Expect(fc.Status().Update(testCtx, pip)).To(Succeed())
+
+			rec := &PublicIPReconciler{
+				Client:                   fc,
+				APIReader:                fc,
+				Scheme:                   testScheme,
+				ComputeInstanceNamespace: testCINamespace,
+			}
+
+			Expect(fc.Get(testCtx, client.ObjectKeyFromObject(pip), pip)).To(Succeed())
+
+			changed, _, err := rec.syncComputeInstanceTargetNamespaceAnnotation(testCtx, pip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeFalse(), "should not change annotation during detach")
+			_, exists := pip.Annotations[osacPublicIPTargetNamespaceAnnotation]
+			Expect(exists).To(BeTrue(), "annotation should be preserved during Releasing state")
+		})
+
 		It("should requeue when ComputeInstance not found", func() {
 			ipMissingCI := &osacv1alpha1.PublicIP{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

[OSAC-776](https://redhat.atlassian.net/browse/OSAC-776): Fix PublicIP detach failing because the `publicip-target-namespace` annotation is cleared before the detach AAP job runs.

## Why

When a PublicIP is detached, the fulfillment-controller removes `spec.computeInstance` from the CR. The operator's `syncComputeInstanceTargetNamespaceAnnotation` method sees `spec.ComputeInstance == ""` and clears the `publicip-target-namespace` annotation. The detach AAP job (`osac-detach-public-ip`) then fails because it needs that annotation to find the LoadBalancer service to delete.

The fix preserves the annotation when the PublicIP state is `Releasing` (detach in progress). The annotation is only cleared once the detach completes and the state returns to `Allocated`.

## Testing

```bash
make lint
# 0 issues.

make test
# ok github.com/osac-project/osac-operator/internal/controller 12.053s coverage: 64.0%
# 358 Passed | 0 Failed
```

New test: "should preserve publicip-target-namespace annotation during detach"
- Calls `syncComputeInstanceTargetNamespaceAnnotation` directly with a PublicIP in Releasing state, empty `spec.ComputeInstance`, and the target-namespace annotation present
- Asserts `changed=false` and annotation is preserved

Existing test "should clear publicip-target-namespace annotation when computeInstance is cleared" continues to pass (non-Releasing state still clears the annotation).

### E2E verification on edge22

Discovered during OSAC-700 PublicIP lifecycle testing on edge22. The attach flow worked end-to-end (ALLOCATED -> ATTACHING -> ATTACHED, with AAP job succeeded). Detach was triggered but the AAP job failed with:

```
PublicIP is missing required fields/annotations: metadata.name, metadata.namespace,
and spec.computeInstance must be set, and annotations osac.openshift.io/publicippool-name
and osac.openshift.io/publicip-target-namespace must both be present.
```

## Ticket

[OSAC-776](https://redhat.atlassian.net/browse/OSAC-776)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PublicIP annotation handling during resource cleanup. When a PublicIP is in the process of being detached from a compute instance, the target namespace annotation is now correctly preserved rather than being prematurely removed. This ensures proper completion of resource cleanup and deprovisioning operations without disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->