### PR TITLE
MGMT-24034: Enable VM access on non-dedicated cluster mode

### DIFF
--- a/config/console-proxy/clusterrole.yaml
+++ b/config/console-proxy/clusterrole.yaml
@@ -10,3 +10,11 @@ rules:
   verbs:
   - get
   - list
+# Used when deployed on the same cluster as KubeVirt VMs (local/auto vm-cluster-mode).
+# In remote mode the proxy authenticates via a kubeconfig Secret instead.
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/console
+  verbs:
+  - get


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated console proxy permissions to enable access to virtual machine console resources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/237)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->