### PR TITLE
OSAC-749: Add Public IP Address field to CI CR

### DIFF
--- a/api/v1alpha1/computeinstance_types.go
+++ b/api/v1alpha1/computeinstance_types.go
@@ -298,6 +298,11 @@ type ComputeInstanceStatus struct {
 	// Populated when the instance is ready (phase Running).
 	// +kubebuilder:validation:Optional
 	IPAddress string `json:"ipAddress,omitempty"`
+
+	// PublicIPAddress is the public IP address attached to this instance via a PublicIP CR.
+	// Populated when a PublicIP CR in state "Attached" references this ComputeInstance.
+	// +kubebuilder:validation:Optional
+	PublicIPAddress string `json:"publicIPAddress,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -309,6 +314,7 @@ type ComputeInstanceStatus struct {
 // +kubebuilder:printcolumn:name="RunStrategy",type=string,JSONPath=`.spec.runStrategy`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="IP",type=string,JSONPath=`.status.ipAddress`
+// +kubebuilder:printcolumn:name="PublicIP",type=string,JSONPath=`.status.publicIPAddress`,priority=1
 
 // ComputeInstance is the Schema for the computeinstances API
 type ComputeInstance struct {

--- a/api/v1alpha1/computeinstance_virtualmachinereference.go
+++ b/api/v1alpha1/computeinstance_virtualmachinereference.go
@@ -67,3 +67,11 @@ func (ci *ComputeInstance) SetIPAddress(ip string) {
 func (ci *ComputeInstance) GetIPAddress() string {
 	return ci.Status.IPAddress
 }
+
+func (ci *ComputeInstance) SetPublicIPAddress(ip string) {
+	ci.Status.PublicIPAddress = ip
+}
+
+func (ci *ComputeInstance) GetPublicIPAddress() string {
+	return ci.Status.PublicIPAddress
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -387,6 +387,7 @@ func setupComputeInstanceControllers(
 	localMgr := mgr.GetLocalManager()
 	computeInstanceNamespace := os.Getenv(envComputeInstanceNamespace)
 	tenantNamespace := os.Getenv(envTenantNamespace)
+	networkingNamespace := os.Getenv(envNetworkingNamespace)
 	targetCluster := targetClusterFromManager(mgr)
 	computeInstanceProvider, statusPollInterval, err := createProviderFromEnv(
 		envComputeInstanceProvisionWebhook, envComputeInstanceDeprovisionWebhook,
@@ -409,6 +410,7 @@ func setupComputeInstanceControllers(
 		mgr,
 		computeInstanceNamespace,
 		tenantNamespace,
+		networkingNamespace,
 		computeInstanceProvider,
 		statusPollInterval,
 		maxJobHistory,

--- a/config/crd/bases/osac.openshift.io_computeinstances.yaml
+++ b/config/crd/bases/osac.openshift.io_computeinstances.yaml
@@ -35,6 +35,10 @@ spec:
     - jsonPath: .status.ipAddress
       name: IP
       type: string
+    - jsonPath: .status.publicIPAddress
+      name: PublicIP
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -407,6 +411,11 @@ spec:
                 - Stopping
                 - Stopped
                 - Paused
+                type: string
+              publicIPAddress:
+                description: |-
+                  PublicIPAddress is the public IP address attached to this instance via a PublicIP CR.
+                  Populated when a PublicIP CR in state "Attached" references this ComputeInstance.
                 type: string
               tenantReference:
                 description: Reference to the tenant that contains the ComputeInstance

--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -68,6 +68,7 @@ type ComputeInstanceReconciler struct {
 	mgr                      mcmanager.Manager
 	ComputeInstanceNamespace string
 	TenantNamespace          string
+	NetworkingNamespace      string
 	ProvisioningProvider     provisioning.ProvisioningProvider
 	// StatusPollInterval defines how often to check provisioning job status
 	StatusPollInterval time.Duration
@@ -80,6 +81,7 @@ func NewComputeInstanceReconciler(
 	mgr mcmanager.Manager,
 	computeInstanceNamespace string,
 	tenantNamespace string,
+	networkingNamespace string,
 	provisioningProvider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration,
 	maxJobHistory int,
@@ -108,6 +110,7 @@ func NewComputeInstanceReconciler(
 		mgr:                      mgr,
 		ComputeInstanceNamespace: computeInstanceNamespace,
 		TenantNamespace:          tenantNamespace,
+		NetworkingNamespace:      networkingNamespace,
 		ProvisioningProvider:     provisioningProvider,
 		StatusPollInterval:       statusPollInterval,
 		MaxJobHistory:            maxJobHistory,
@@ -118,6 +121,7 @@ func NewComputeInstanceReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=computeinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=computeinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=computeinstances/finalizers,verbs=update
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicips,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines;virtualmachineinstances,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
@@ -238,6 +242,13 @@ func (r *ComputeInstanceReconciler) SetupWithManager(mgr mcmanager.Manager) erro
 			mcbuilder.WithEngageWithLocalCluster(true),
 			mcbuilder.WithEngageWithProviderClusters(false),
 		).
+		Watches(
+			&v1alpha1.PublicIP{},
+			mchandler.EnqueueRequestsFromMapFunc(r.mapPublicIPToComputeInstance),
+			mcbuilder.WithPredicates(NetworkingNamespacePredicate(r.NetworkingNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false),
+		).
 		Complete(r)
 }
 
@@ -315,6 +326,77 @@ func (r *ComputeInstanceReconciler) mapTenantToComputeInstances(ctx context.Cont
 		"computeinstances", computeInstances.Items,
 	)
 	return requests
+}
+
+// mapPublicIPToComputeInstance maps a PublicIP change to the ComputeInstance it references
+// via spec.computeInstance (CI UUID). This triggers a CI reconcile when a PublicIP is
+// attached, detached, or has its address updated.
+func (r *ComputeInstanceReconciler) mapPublicIPToComputeInstance(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := ctrllog.FromContext(ctx)
+
+	publicIP, ok := obj.(*v1alpha1.PublicIP)
+	if !ok {
+		return nil
+	}
+
+	ciUUID := publicIP.Spec.ComputeInstance
+	if ciUUID == "" {
+		return nil
+	}
+
+	ciList := &v1alpha1.ComputeInstanceList{}
+	if err := r.List(ctx, ciList,
+		client.InNamespace(r.ComputeInstanceNamespace),
+		client.MatchingLabels{osacComputeInstanceIDLabel: ciUUID},
+	); err != nil {
+		log.Error(err, "failed to list ComputeInstances for PublicIP watch")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range ciList.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&ciList.Items[i]),
+		})
+	}
+
+	if len(requests) > 0 {
+		log.Info("mapped PublicIP change to ComputeInstance",
+			"publicIP", publicIP.Name,
+			"computeInstanceUUID", ciUUID,
+		)
+	}
+
+	return requests
+}
+
+// syncPublicIPAddress looks up attached PublicIP CRs and populates status.publicIPAddress.
+func (r *ComputeInstanceReconciler) syncPublicIPAddress(ctx context.Context, instance *v1alpha1.ComputeInstance) {
+	log := ctrllog.FromContext(ctx)
+
+	ciUUID, ok := instance.Labels[osacComputeInstanceIDLabel]
+	if !ok {
+		instance.SetPublicIPAddress("")
+		return
+	}
+
+	publicIPs := &v1alpha1.PublicIPList{}
+	if err := r.List(ctx, publicIPs, client.InNamespace(r.NetworkingNamespace)); err != nil {
+		log.Error(err, "failed to list PublicIPs for public IP address sync")
+		return
+	}
+
+	for i := range publicIPs.Items {
+		pip := &publicIPs.Items[i]
+		if pip.Spec.ComputeInstance == ciUUID &&
+			pip.Status.State == v1alpha1.PublicIPStateAttached &&
+			pip.Status.Address != "" {
+			instance.SetPublicIPAddress(pip.Status.Address)
+			return
+		}
+	}
+
+	instance.SetPublicIPAddress("")
 }
 
 // handleProvisioning manages the provisioning job lifecycle for a ComputeInstance.
@@ -707,6 +789,8 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 	if len(tenant.Status.StorageClasses) > 0 {
 		ctx = provisioning.WithTenantStorageClasses(ctx, tenant.Status.StorageClasses)
 	}
+
+	r.syncPublicIPAddress(ctx, instance)
 
 	// Always delegate to provisioning lifecycle — EvaluateAction decides
 	// whether to skip, poll, or trigger. This avoids the A-B-A problem where

--- a/internal/controller/computeinstance_controller_test.go
+++ b/internal/controller/computeinstance_controller_test.go
@@ -143,7 +143,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 
 			By("Reconciling the deleted resource")
 			Eventually(func() error {
-				controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+				controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 				_, err := controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{
 					NamespacedName: typeNamespacedName,
 				}})
@@ -157,7 +157,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 		})
 		It("should successfully reconcile the resource", func() {
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			// Reconcile inside Eventually: the first call may requeue if
 			// the envtest cache has not yet propagated the Tenant status
@@ -213,7 +213,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 				},
 			}
 			controllerReconciler := NewComputeInstanceReconciler(
-				testMcManager, "", namespaceName,
+				testMcManager, "", "", namespaceName,
 				mockProv,
 				100*time.Millisecond, 0, mcmanager.LocalCluster,
 			)
@@ -244,7 +244,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 		ctx := context.Background()
 
 		BeforeEach(func() {
-			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
+			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
 		})
 
 		It("should compute and store a version of the spec", func() {
@@ -388,7 +388,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 		ctx := context.Background()
 
 		BeforeEach(func() {
-			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
+			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
 		})
 
 		It("returns the first interface IP from the VMI status", func() {
@@ -474,7 +474,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			var reconciler *ComputeInstanceReconciler
 
 			BeforeEach(func() {
-				reconciler = NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 0, 3, mcmanager.LocalCluster)
+				reconciler = NewComputeInstanceReconciler(testMcManager, "", "", "", &mockProvisioningProvider{}, 0, 3, mcmanager.LocalCluster)
 			})
 
 			It("should append job to empty slice", func() {
@@ -593,7 +593,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			})
 
 			It("should use default max history when set", func() {
-				reconciler := NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 0, provisioning.DefaultMaxJobHistory, mcmanager.LocalCluster)
+				reconciler := NewComputeInstanceReconciler(testMcManager, "", "", "", &mockProvisioningProvider{}, 0, provisioning.DefaultMaxJobHistory, mcmanager.LocalCluster)
 				jobs := []osacv1alpha1.JobStatus{}
 				// Add 15 jobs
 				baseTime := time.Now().UTC()
@@ -1022,7 +1022,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			// Wait for the CI to appear in the controller's cache before calling Reconcile
 			// directly. Without this, r.Get() inside Reconcile returns NotFound (cache miss)
@@ -1075,7 +1075,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 					}, nil
 				},
 			}
-			reconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, provider, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			reconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", provider, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			Eventually(func() error {
 				return reconciler.Client.Get(ctx, objectKey, &osacv1alpha1.ComputeInstance{})
@@ -1114,7 +1114,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			// Wait for the CI to appear in the controller's cache before calling Reconcile directly.
 			Eventually(func() error {
@@ -1331,7 +1331,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
+			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
 			var err error
 			targetClient, err = getTargetClient(ctx, reconciler.mgr, reconciler.targetCluster)
 			Expect(err).NotTo(HaveOccurred())
@@ -1529,7 +1529,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			fakeRecorder := events.NewFakeRecorder(100)
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 			controllerReconciler.Recorder = fakeRecorder
 
 			Eventually(func() error {
@@ -1588,7 +1588,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			fakeRecorder := events.NewFakeRecorder(100)
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 			controllerReconciler.Recorder = fakeRecorder
 
 			Eventually(func() error {
@@ -1710,7 +1710,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 				return mgrClient.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
 			}).Should(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			// First reconcile: sets tenant reference
 			_, err := controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{NamespacedName: nn}})
@@ -1777,7 +1777,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 				return mgrClient.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
 			}).Should(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			// Reconcile should fail because tenant does not exist
 			_, err := controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{NamespacedName: nn}})
@@ -1827,7 +1827,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 			Eventually(func() error {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
 			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
@@ -1880,7 +1880,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 			Eventually(func() error {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
 			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
@@ -1934,7 +1934,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 			Eventually(func() error {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
 			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
@@ -1989,7 +1989,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			reconciler = NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
+			reconciler = NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
 		})
 
 		It("should return empty string when subnetRef is not set", func() {
@@ -2120,7 +2120,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			Eventually(func() error {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
@@ -2161,7 +2161,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			Eventually(func() error {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
@@ -2197,7 +2197,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 				_ = k8sClient.Delete(ctx, subnet)
 			}()
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			// Wait for Subnet CR to be cached by the reconciler's manager cache
 			Eventually(func() error {
@@ -2258,7 +2258,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 				_ = k8sClient.Delete(ctx, subnet)
 			}()
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			// Wait for Subnet CR to be cached by the reconciler's manager cache
 			Eventually(func() error {
@@ -2329,7 +2329,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			Eventually(func() error {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
@@ -2353,7 +2353,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 		ctx := context.Background()
 
 		BeforeEach(func() {
-			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
+			reconciler = NewComputeInstanceReconciler(testMcManager, "", "", "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
 		})
 
 		It("should set lastRestartedAt when restartRequestedAt is set and config versions match", func() {
@@ -2640,7 +2640,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
+			controllerReconciler := NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{name: string(provisioning.ProviderTypeAAP)}, 100*time.Millisecond, 0, mcmanager.LocalCluster)
 
 			Eventually(func() error {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
@@ -2658,6 +2658,281 @@ var _ = Describe("ComputeInstance Controller", func() {
 				g.Expect(ci.Annotations).To(HaveKey(osacSubnetTargetNamespaceAnnotation))
 				g.Expect(ci.Annotations[osacSubnetTargetNamespaceAnnotation]).To(Equal(subnetRef))
 			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+		})
+	})
+
+	Context("syncPublicIPAddress", func() {
+		var reconciler *ComputeInstanceReconciler
+		const networkingNS = "default"
+		const ciUUID = "ci-uuid-sync-test"
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			reconciler = NewComputeInstanceReconciler(testMcManager, "", "default", networkingNS, &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
+		})
+
+		It("populates publicIPAddress from an attached PublicIP", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-sync-attached",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            "pool-uuid",
+					ComputeInstance: ciUUID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, pip)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pip) })
+			pip.Status.State = osacv1alpha1.PublicIPStateAttached
+			pip.Status.Address = "203.0.113.10"
+			Expect(k8sClient.Status().Update(ctx, pip)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				p := &osacv1alpha1.PublicIP{}
+				g.Expect(testMcManager.GetLocalManager().GetClient().Get(ctx, client.ObjectKeyFromObject(pip), p)).To(Succeed())
+				g.Expect(p.Status.State).To(Equal(osacv1alpha1.PublicIPStateAttached))
+			}).Should(Succeed())
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{osacComputeInstanceIDLabel: ciUUID},
+				},
+			}
+			reconciler.syncPublicIPAddress(ctx, ci)
+			Expect(ci.GetPublicIPAddress()).To(Equal("203.0.113.10"))
+		})
+
+		It("does not populate when PublicIP is not in Attached state", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-sync-allocated",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            "pool-uuid",
+					ComputeInstance: ciUUID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, pip)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pip) })
+			pip.Status.State = osacv1alpha1.PublicIPStateAllocated
+			pip.Status.Address = "203.0.113.11"
+			Expect(k8sClient.Status().Update(ctx, pip)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				p := &osacv1alpha1.PublicIP{}
+				g.Expect(testMcManager.GetLocalManager().GetClient().Get(ctx, client.ObjectKeyFromObject(pip), p)).To(Succeed())
+				g.Expect(p.Status.State).To(Equal(osacv1alpha1.PublicIPStateAllocated))
+			}).Should(Succeed())
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{osacComputeInstanceIDLabel: ciUUID},
+				},
+			}
+			reconciler.syncPublicIPAddress(ctx, ci)
+			Expect(ci.GetPublicIPAddress()).To(BeEmpty())
+		})
+
+		It("clears publicIPAddress when CI has no UUID label", func() {
+			ci := &osacv1alpha1.ComputeInstance{
+				Status: osacv1alpha1.ComputeInstanceStatus{
+					PublicIPAddress: "stale-ip",
+				},
+			}
+			reconciler.syncPublicIPAddress(ctx, ci)
+			Expect(ci.GetPublicIPAddress()).To(BeEmpty())
+		})
+
+		It("clears publicIPAddress when PublicIP address is empty", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-sync-empty-addr",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            "pool-uuid",
+					ComputeInstance: ciUUID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, pip)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pip) })
+			pip.Status.State = osacv1alpha1.PublicIPStateAttached
+			pip.Status.Address = ""
+			Expect(k8sClient.Status().Update(ctx, pip)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				p := &osacv1alpha1.PublicIP{}
+				g.Expect(testMcManager.GetLocalManager().GetClient().Get(ctx, client.ObjectKeyFromObject(pip), p)).To(Succeed())
+				g.Expect(p.Status.State).To(Equal(osacv1alpha1.PublicIPStateAttached))
+			}).Should(Succeed())
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{osacComputeInstanceIDLabel: ciUUID},
+				},
+			}
+			reconciler.syncPublicIPAddress(ctx, ci)
+			Expect(ci.GetPublicIPAddress()).To(BeEmpty())
+		})
+
+		It("does not populate when PublicIP references a different CI", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-sync-other-ci",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            "pool-uuid",
+					ComputeInstance: "other-ci-uuid",
+				},
+			}
+			Expect(k8sClient.Create(ctx, pip)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pip) })
+			pip.Status.State = osacv1alpha1.PublicIPStateAttached
+			pip.Status.Address = "203.0.113.12"
+			Expect(k8sClient.Status().Update(ctx, pip)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				p := &osacv1alpha1.PublicIP{}
+				g.Expect(testMcManager.GetLocalManager().GetClient().Get(ctx, client.ObjectKeyFromObject(pip), p)).To(Succeed())
+				g.Expect(p.Status.State).To(Equal(osacv1alpha1.PublicIPStateAttached))
+			}).Should(Succeed())
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{osacComputeInstanceIDLabel: ciUUID},
+				},
+			}
+			reconciler.syncPublicIPAddress(ctx, ci)
+			Expect(ci.GetPublicIPAddress()).To(BeEmpty())
+		})
+
+		It("clears publicIPAddress when PublicIP is detached", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-sync-detach",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            "pool-uuid",
+					ComputeInstance: ciUUID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, pip)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pip) })
+			pip.Status.State = osacv1alpha1.PublicIPStateAttached
+			pip.Status.Address = "203.0.113.13"
+			Expect(k8sClient.Status().Update(ctx, pip)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				p := &osacv1alpha1.PublicIP{}
+				g.Expect(testMcManager.GetLocalManager().GetClient().Get(ctx, client.ObjectKeyFromObject(pip), p)).To(Succeed())
+				g.Expect(p.Status.State).To(Equal(osacv1alpha1.PublicIPStateAttached))
+			}).Should(Succeed())
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{osacComputeInstanceIDLabel: ciUUID},
+				},
+			}
+			reconciler.syncPublicIPAddress(ctx, ci)
+			Expect(ci.GetPublicIPAddress()).To(Equal("203.0.113.13"))
+
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pip), pip)).To(Succeed())
+			pip.Status.State = osacv1alpha1.PublicIPStateReleasing
+			Expect(k8sClient.Status().Update(ctx, pip)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				p := &osacv1alpha1.PublicIP{}
+				g.Expect(testMcManager.GetLocalManager().GetClient().Get(ctx, client.ObjectKeyFromObject(pip), p)).To(Succeed())
+				g.Expect(p.Status.State).To(Equal(osacv1alpha1.PublicIPStateReleasing))
+			}).Should(Succeed())
+
+			reconciler.syncPublicIPAddress(ctx, ci)
+			Expect(ci.GetPublicIPAddress()).To(BeEmpty())
+		})
+	})
+
+	Context("mapPublicIPToComputeInstance", func() {
+		var reconciler *ComputeInstanceReconciler
+		const ciNS = "default"
+		const networkingNS = "default"
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			reconciler = NewComputeInstanceReconciler(testMcManager, ciNS, "default", networkingNS, &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
+		})
+
+		It("returns reconcile request for matching ComputeInstance", func() {
+			const mapCIUUID = "ci-uuid-map-match"
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-map-match",
+					Namespace: ciNS,
+					Labels: map[string]string{
+						osacComputeInstanceIDLabel: mapCIUUID,
+					},
+					Annotations: map[string]string{
+						osacTenantAnnotation: "dummy",
+					},
+				},
+				Spec: newTestComputeInstanceSpec("test_template"),
+			}
+			Expect(k8sClient.Create(ctx, ci)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, ci) })
+
+			Eventually(func() error {
+				return testMcManager.GetLocalManager().GetClient().Get(ctx, client.ObjectKeyFromObject(ci), &osacv1alpha1.ComputeInstance{})
+			}).Should(Succeed())
+
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-map-match",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            "pool-uuid",
+					ComputeInstance: mapCIUUID,
+				},
+			}
+
+			requests := reconciler.mapPublicIPToComputeInstance(ctx, pip)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName.Name).To(Equal("ci-map-match"))
+			Expect(requests[0].NamespacedName.Namespace).To(Equal(ciNS))
+		})
+
+		It("returns nil when PublicIP has no computeInstance", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-map-empty",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool: "pool-uuid",
+				},
+			}
+
+			requests := reconciler.mapPublicIPToComputeInstance(ctx, pip)
+			Expect(requests).To(BeNil())
+		})
+
+		It("returns empty when no CI matches the UUID", func() {
+			pip := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-map-nomatch",
+					Namespace: networkingNS,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            "pool-uuid",
+					ComputeInstance: "nonexistent-uuid",
+				},
+			}
+
+			requests := reconciler.mapPublicIPToComputeInstance(ctx, pip)
+			Expect(requests).To(BeEmpty())
 		})
 	})
 })

--- a/internal/controller/computeinstance_feedback_controller.go
+++ b/internal/controller/computeinstance_feedback_controller.go
@@ -408,7 +408,7 @@ func (t *computeInstanceFeedbackReconcilerTask) findComputeInstanceCondition(kin
 }
 
 func (t *computeInstanceFeedbackReconcilerTask) syncIPAddresses() {
-	t.ci.GetStatus().SetPublicIpAddress(t.object.Annotations[osacComputeInstancePublicIPAddressAnnotation])
+	t.ci.GetStatus().SetPublicIpAddress(t.object.Status.PublicIPAddress)
 	t.ci.GetStatus().SetInternalIpAddress(t.object.Status.IPAddress)
 }
 

--- a/internal/controller/computeinstance_feedback_controller_test.go
+++ b/internal/controller/computeinstance_feedback_controller_test.go
@@ -932,13 +932,11 @@ var _ = Describe("ComputeInstanceFeedbackReconciler", func() {
 			Expect(found).To(BeTrue())
 		})
 
-		It("should sync public IP address from annotation", func() {
+		It("should sync public IP address from status", func() {
 			computeInstance := &osacv1alpha1.ComputeInstance{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
-			computeInstance.Annotations = map[string]string{
-				osacComputeInstancePublicIPAddressAnnotation: "10.0.0.100",
-			}
-			Expect(k8sClient.Update(ctx, computeInstance)).To(Succeed())
+			computeInstance.Status.PublicIPAddress = "10.0.0.100"
+			Expect(k8sClient.Status().Update(ctx, computeInstance)).To(Succeed())
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
@@ -961,12 +959,7 @@ var _ = Describe("ComputeInstanceFeedbackReconciler", func() {
 		It("should sync both public and internal IP addresses when both are set", func() {
 			computeInstance := &osacv1alpha1.ComputeInstance{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
-			computeInstance.Annotations = map[string]string{
-				osacComputeInstancePublicIPAddressAnnotation: "10.0.0.100",
-			}
-			Expect(k8sClient.Update(ctx, computeInstance)).To(Succeed())
-
-			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
+			computeInstance.Status.PublicIPAddress = "10.0.0.100"
 			computeInstance.Status.IPAddress = "192.168.1.50"
 			Expect(k8sClient.Status().Update(ctx, computeInstance)).To(Succeed())
 
@@ -977,7 +970,7 @@ var _ = Describe("ComputeInstanceFeedbackReconciler", func() {
 			Expect(mockClient.lastUpdate.GetStatus().GetInternalIpAddress()).To(Equal("192.168.1.50"))
 		})
 
-		It("should clear IP addresses when neither public annotation nor internal IP is set", func() {
+		It("should clear IP addresses when neither public IP status nor internal IP is set", func() {
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockClient.updateCalled).To(BeTrue())
@@ -985,22 +978,20 @@ var _ = Describe("ComputeInstanceFeedbackReconciler", func() {
 			Expect(mockClient.lastUpdate.GetStatus().GetInternalIpAddress()).To(BeEmpty())
 		})
 
-		It("should clear public IP when annotation is removed after detach", func() {
+		It("should clear public IP when status field is cleared after detach", func() {
 			computeInstance := &osacv1alpha1.ComputeInstance{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
-			computeInstance.Annotations = map[string]string{
-				osacComputeInstancePublicIPAddressAnnotation: "10.0.0.100",
-			}
-			Expect(k8sClient.Update(ctx, computeInstance)).To(Succeed())
+			computeInstance.Status.PublicIPAddress = "10.0.0.100"
+			Expect(k8sClient.Status().Update(ctx, computeInstance)).To(Succeed())
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockClient.lastUpdate.GetStatus().GetPublicIpAddress()).To(Equal("10.0.0.100"))
 
-			// Simulate detach: remove the annotation
+			// Simulate detach: clear the status field
 			Expect(k8sClient.Get(ctx, typeNamespacedName, computeInstance)).To(Succeed())
-			delete(computeInstance.Annotations, osacComputeInstancePublicIPAddressAnnotation)
-			Expect(k8sClient.Update(ctx, computeInstance)).To(Succeed())
+			computeInstance.Status.PublicIPAddress = ""
+			Expect(k8sClient.Status().Update(ctx, computeInstance)).To(Succeed())
 
 			mockClient.updateCalled = false
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})

--- a/internal/controller/computeinstance_integration_test.go
+++ b/internal/controller/computeinstance_integration_test.go
@@ -166,7 +166,7 @@ var _ = Describe("ComputeInstance Integration Tests", func() {
 
 	BeforeEach(func() {
 		provider = newControllableProvider()
-		reconciler = NewComputeInstanceReconciler(testMcManager, testNamespace, testNamespace, provider, 100*time.Millisecond, provisioning.DefaultMaxJobHistory, mcmanager.LocalCluster)
+		reconciler = NewComputeInstanceReconciler(testMcManager, testNamespace, testNamespace, "", provider, 100*time.Millisecond, provisioning.DefaultMaxJobHistory, mcmanager.LocalCluster)
 	})
 
 	Context("Provisioning workflow", func() {

--- a/internal/controller/computeinstance_names.go
+++ b/internal/controller/computeinstance_names.go
@@ -40,6 +40,5 @@ var (
 	osacComputeInstanceFinalizer                 string = fmt.Sprintf("%s/computeinstance", osacPrefix)
 	osacComputeInstanceFeedbackFinalizer         string = fmt.Sprintf("%s/computeinstance-feedback", osacPrefix)
 	osacComputeInstanceManagementStateAnnotation string = fmt.Sprintf("%s/management-state", osacPrefix)
-	osacComputeInstancePublicIPAddressAnnotation string = fmt.Sprintf("%s/public-ip-address", osacPrefix)
 	osacSubnetTargetNamespaceAnnotation          string = fmt.Sprintf("%s/subnet-target-namespace", osacPrefix)
 )

--- a/internal/controller/computeinstance_provisioning_test.go
+++ b/internal/controller/computeinstance_provisioning_test.go
@@ -105,7 +105,7 @@ var _ = Describe("ComputeInstance Provisioning", func() {
 			Spec:   newTestComputeInstanceSpec("test_template"),
 			Status: osacv1alpha1.ComputeInstanceStatus{DesiredConfigVersion: "initial"},
 		}
-		reconciler = NewComputeInstanceReconciler(testMcManager, "", "", &mockProvisioningProvider{}, 30*time.Second, provisioning.DefaultMaxJobHistory, mcmanager.LocalCluster)
+		reconciler = NewComputeInstanceReconciler(testMcManager, "", "", "", &mockProvisioningProvider{}, 30*time.Second, provisioning.DefaultMaxJobHistory, mcmanager.LocalCluster)
 	})
 
 	Context("handleProvisioning", func() {


### PR DESCRIPTION
[OSAC-749](https://redhat.atlassian.net/browse/OSAC-749)

Adds a public ip address field to the ComputeInstance CR.  replaces a previously used annotation (will remove the AAP portion as a follow up).  Also allows the ip to be displayed by cli calls such as oc get computeinstance:

```
$ oc --as=system:admin -n osac-dakcrowder get computeinstance vm-2ckc7 -o wide
NAME       TEMPLATE                     CORES   MEMORY   RUNSTRATEGY   PHASE      IP    PUBLICIP
vm-2ckc7   osac.templates.ocp_virt_vm   2       2        Always        Starting         203.0.113.42
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ComputeInstance resources now include a public IP status field and show a "PublicIP" column in listings.

* **Improvements**
  * Public IPs from PublicIP resources are synchronized into ComputeInstance status for accurate, up-to-date display.
  * Controller behavior updated to surface public IP changes promptly in listings and status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->