### PR TITLE
NO-ISSUE: add make tag-api target for API module releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,13 +185,16 @@ open(sys.argv[2], 'w').write(content)" \
 ##@ API Module
 
 API_VERSION ?= $(error API_VERSION is required (e.g. make tag-api API_VERSION=v0.0.2))
+TAG_REMOTE ?= upstream
 
 .PHONY: tag-api
 tag-api: ## Tag a new release of the api/ Go module (e.g. make tag-api API_VERSION=v0.0.2).
+	@echo "$(API_VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || \
+		{ echo "Error: API_VERSION must match vX.Y.Z (got '$(API_VERSION)')"; exit 1; }
 	@if [ -z "$(shell git status --porcelain)" ]; then \
 		echo "Tagging api/$(API_VERSION)..." ; \
 		git tag "api/$(API_VERSION)" ; \
-		git push upstream "api/$(API_VERSION)" ; \
+		git push $(TAG_REMOTE) "api/$(API_VERSION)" ; \
 		echo "Tagged and pushed api/$(API_VERSION)" ; \
 	else \
 		echo "Error: working tree is dirty — commit or stash changes first" ; \

--- a/Makefile
+++ b/Makefile
@@ -185,17 +185,21 @@ open(sys.argv[2], 'w').write(content)" \
 ##@ API Module
 
 API_VERSION ?= $(error API_VERSION is required (e.g. make tag-api API_VERSION=v0.0.2))
-TAG_REMOTE ?= upstream
 
 .PHONY: tag-api
 tag-api: ## Tag a new release of the api/ Go module (e.g. make tag-api API_VERSION=v0.0.2).
 	@echo "$(API_VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || \
 		{ echo "Error: API_VERSION must match vX.Y.Z (got '$(API_VERSION)')"; exit 1; }
-	@if [ -z "$(shell git status --porcelain)" ]; then \
-		echo "Tagging api/$(API_VERSION)..." ; \
+	@REMOTE=$$(git remote -v | grep 'osac-project/osac-operator' | grep '(push)' | awk '{print $$1}' | head -1); \
+	if [ -z "$$REMOTE" ]; then \
+		echo "Error: no remote found pointing to osac-project/osac-operator"; \
+		exit 1; \
+	fi; \
+	if [ -z "$$(git status --porcelain)" ]; then \
+		echo "Tagging api/$(API_VERSION) and pushing to $$REMOTE..." ; \
 		git tag "api/$(API_VERSION)" ; \
-		git push $(TAG_REMOTE) "api/$(API_VERSION)" ; \
-		echo "Tagged and pushed api/$(API_VERSION)" ; \
+		git push "$$REMOTE" "api/$(API_VERSION)" ; \
+		echo "Tagged and pushed api/$(API_VERSION) to $$REMOTE" ; \
 	else \
 		echo "Error: working tree is dirty — commit or stash changes first" ; \
 		exit 1 ; \

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,22 @@ open(sys.argv[2], 'w').write(content)" \
 	done
 	@echo "Done."
 
+##@ API Module
+
+API_VERSION ?= $(error API_VERSION is required (e.g. make tag-api API_VERSION=v0.0.2))
+
+.PHONY: tag-api
+tag-api: ## Tag a new release of the api/ Go module (e.g. make tag-api API_VERSION=v0.0.2).
+	@if [ -z "$(shell git status --porcelain)" ]; then \
+		echo "Tagging api/$(API_VERSION)..." ; \
+		git tag "api/$(API_VERSION)" ; \
+		git push upstream "api/$(API_VERSION)" ; \
+		echo "Tagged and pushed api/$(API_VERSION)" ; \
+	else \
+		echo "Error: working tree is dirty — commit or stash changes first" ; \
+		exit 1 ; \
+	fi
+
 ##@ Build
 
 .PHONY: build


### PR DESCRIPTION
## Summary

- Adds a `make tag-api API_VERSION=v0.0.2` Makefile target for tagging releases of the `api/` Go module
- The `api/` directory is a separate Go module (`github.com/osac-project/osac-operator/api`) consumed by fulfillment-service without pulling in controller-runtime
- Tagging requires Go's nested module convention (`api/vX.Y.Z`) — this target makes the process discoverable via `make help` and repeatable
- Includes a dirty-tree guard to prevent tagging uncommitted changes

## Test plan

- [ ] `make help` shows the `tag-api` target under "API Module" section
- [ ] `make tag-api` without `API_VERSION` shows a clear error
- [ ] `make tag-api API_VERSION=v0.0.2` on a dirty tree shows an error

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release tagging infrastructure for the API module with validation to ensure clean repository state before creating version tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->