### PR TITLE
Fix image publish race on rapid main merges

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -8,8 +8,8 @@ on:
     - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Same fix as osac-project/fulfillment-service#568.

When multiple PRs merge to main within seconds, cancel-in-progress kills earlier image builds. Change concurrency group from github.ref to github.sha so each commit gets its own group. Only cancel for PRs, not main pushes.