### PR TITLE
OSAC-835: add PublicIPAttachment controller with provisioning lifecycle

### DIFF
--- a/api/v1alpha1/publicip_types.go
+++ b/api/v1alpha1/publicip_types.go
@@ -105,6 +105,10 @@ type PublicIPStatus struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Enum=Pending;Allocated;Attaching;Attached;Releasing;Failed
 	State PublicIPStateType `json:"state,omitempty"`
+
+	// Attached indicates whether a PublicIPAttachment has successfully attached this IP to a target.
+	// +kubebuilder:validation:Optional
+	Attached bool `json:"attached,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -469,7 +469,8 @@ func setupNetworkingControllers(
 	// and TriggerDeprovision hardcodes action="delete" in resolveTemplateName. Explicit
 	// names bypass the action resolution so TriggerProvision maps to
 	// {prefix}-attach-public-ip and TriggerDeprovision maps to {prefix}-detach-public-ip.
-	// This provider will move to the PublicIPAttachment controller when that CRD is introduced.
+	// This provider is shared between the PublicIP controller (inline attach/detach, to be
+	// removed in OSAC-836) and the PublicIPAttachment controller.
 	// Poll interval is discarded (_) because we reuse statusPollInterval from the
 	// shared networking setup above. minimumRequestInterval is passed for EDA webhook
 	// rate limiting when OSAC_PROVISIONING_PROVIDER=eda.
@@ -560,6 +561,14 @@ func setupNetworkingControllers(
 		networkingProvider, publicIPAttachmentProvider, statusPollInterval, maxJobHistory, targetCluster,
 	).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("publicip controller: %w", err)
+	}
+
+	// Setup PublicIPAttachment controller (uses the same attach/detach provider as PublicIP)
+	if err := controller.NewPublicIPAttachmentReconciler(
+		mgr, networkingNamespace, computeInstanceNamespace,
+		publicIPAttachmentProvider, statusPollInterval, maxJobHistory, targetCluster,
+	).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("publicipattachment controller: %w", err)
 	}
 
 	// Setup PublicIP feedback controller

--- a/config/crd/bases/osac.openshift.io_publicips.yaml
+++ b/config/crd/bases/osac.openshift.io_publicips.yaml
@@ -81,6 +81,10 @@ spec:
               address:
                 description: Address is the allocated public IP address
                 type: string
+              attached:
+                description: Attached indicates whether a PublicIPAttachment has successfully
+                  attached this IP to a target.
+                type: boolean
               conditions:
                 description: Conditions holds an array of metav1.Condition that describe
                   the state of the PublicIP

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,7 @@ rules:
   resources:
   - clusterorders
   - computeinstances
+  - publicipattachments
   - publicippools
   - publicips
   - securitygroups
@@ -85,6 +86,7 @@ rules:
   resources:
   - clusterorders/finalizers
   - computeinstances/finalizers
+  - publicipattachments/finalizers
   - publicippools/finalizers
   - publicips/finalizers
   - securitygroups/finalizers
@@ -98,6 +100,7 @@ rules:
   resources:
   - clusterorders/status
   - computeinstances/status
+  - publicipattachments/status
   - publicippools/status
   - publicips/status
   - securitygroups/status

--- a/internal/controller/constants_common.go
+++ b/internal/controller/constants_common.go
@@ -43,4 +43,7 @@ const (
 	defaultPublicIPPoolImplementationStrategy = "metallb-l2"
 
 	deprovisioningJobTriggeredMessage = "Deprovisioning job triggered"
+
+	conditionReasonConfigurationApplied  = "ConfigurationApplied"
+	conditionMessageConfigurationApplied = "Controller has processed the current spec"
 )

--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -260,8 +260,8 @@ func (r *PublicIPReconciler) handleUpdate(ctx context.Context, publicIP *v1alpha
 	v1alpha1.SetPublicIPStatusCondition(publicIP, metav1.Condition{
 		Type:               string(v1alpha1.PublicIPConditionConfigurationApplied),
 		Status:             metav1.ConditionTrue,
-		Reason:             "ConfigurationApplied",
-		Message:            "Controller has processed the current spec",
+		Reason:             conditionReasonConfigurationApplied,
+		Message:            conditionMessageConfigurationApplied,
 		LastTransitionTime: metav1.Now(),
 	})
 

--- a/internal/controller/publicipattachment_controller.go
+++ b/internal/controller/publicipattachment_controller.go
@@ -1,0 +1,618 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mc "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	"github.com/osac-project/osac-operator/api/v1alpha1"
+	"github.com/osac-project/osac-operator/pkg/provisioning"
+)
+
+const (
+	osacPublicIPAttachmentFinalizer = "osac.openshift.io/publicipattachment-finalizer"
+)
+
+// PublicIPAttachmentReconciler reconciles PublicIPAttachment CRs.
+//
+// Creating a PublicIPAttachment triggers an attach operation (osac-attach-public-ip AAP
+// template) that moves the MetalLB Service from the parking namespace to the VM namespace.
+// Deleting the CR triggers detach (osac-detach-public-ip) which reverses that.
+//
+// The controller uses RunProvisioningLifecycle for provisioning, giving automatic
+// exponential-backoff retry on failure. It also watches ComputeInstance resources to
+// auto-delete the PublicIPAttachment when the target CI is deleted.
+type PublicIPAttachmentReconciler struct {
+	client.Client
+	APIReader                client.Reader
+	Scheme                   *runtime.Scheme
+	mgr                      mcmanager.Manager
+	NetworkingNamespace      string
+	ComputeInstanceNamespace string
+	ProvisioningProvider     provisioning.ProvisioningProvider
+	StatusPollInterval       time.Duration
+	MaxJobHistory            int
+	targetCluster            mc.ClusterName
+}
+
+// NewPublicIPAttachmentReconciler creates a new reconciler for PublicIPAttachment resources.
+func NewPublicIPAttachmentReconciler(
+	mgr mcmanager.Manager,
+	networkingNamespace string,
+	computeInstanceNamespace string,
+	provisioningProvider provisioning.ProvisioningProvider,
+	statusPollInterval time.Duration,
+	maxJobHistory int,
+	targetCluster mc.ClusterName,
+) *PublicIPAttachmentReconciler {
+	if mgr == nil {
+		panic("mgr must not be nil")
+	}
+	if statusPollInterval <= 0 {
+		statusPollInterval = provisioning.DefaultStatusPollInterval
+	}
+	if maxJobHistory <= 0 {
+		maxJobHistory = provisioning.DefaultMaxJobHistory
+	}
+	if computeInstanceNamespace == "" {
+		computeInstanceNamespace = defaultComputeInstanceNamespace
+	}
+	return &PublicIPAttachmentReconciler{
+		Client:                   mgr.GetLocalManager().GetClient(),
+		APIReader:                mgr.GetLocalManager().GetAPIReader(),
+		Scheme:                   mgr.GetLocalManager().GetScheme(),
+		mgr:                      mgr,
+		NetworkingNamespace:      networkingNamespace,
+		ComputeInstanceNamespace: computeInstanceNamespace,
+		ProvisioningProvider:     provisioningProvider,
+		StatusPollInterval:       statusPollInterval,
+		MaxJobHistory:            maxJobHistory,
+		targetCluster:            targetCluster,
+	}
+}
+
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicipattachments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicipattachments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=publicipattachments/finalizers,verbs=update
+
+// Reconcile handles create/update/delete for a PublicIPAttachment CR.
+func (r *PublicIPAttachmentReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	attachment := &v1alpha1.PublicIPAttachment{}
+	if err := r.Get(ctx, req.NamespacedName, attachment); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	val, exists := attachment.Annotations[osacManagementStateAnnotation]
+	if attachment.ObjectMeta.DeletionTimestamp.IsZero() && exists && val == ManagementStateUnmanaged {
+		log.Info("ignoring PublicIPAttachment due to management-state annotation", "management-state", val)
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("start reconcile", "publicIP", attachment.Spec.PublicIP, "phase", attachment.Status.Phase)
+
+	oldstatus := attachment.Status.DeepCopy()
+
+	var res ctrl.Result
+	var err error
+	if attachment.ObjectMeta.DeletionTimestamp.IsZero() {
+		res, err = r.handleUpdate(ctx, attachment)
+	} else {
+		res, err = r.handleDelete(ctx, attachment)
+	}
+
+	if !equality.Semantic.DeepEqual(attachment.Status, *oldstatus) {
+		log.Info("status requires update", "phase", attachment.Status.Phase)
+		if updateErr := r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(attachment), attachment.Status); updateErr != nil {
+			return res, updateErr
+		}
+	}
+
+	log.Info("end reconcile", "phase", attachment.Status.Phase)
+	return res, err
+}
+
+func (r *PublicIPAttachmentReconciler) handleUpdate(ctx context.Context, attachment *v1alpha1.PublicIPAttachment) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	if controllerutil.AddFinalizer(attachment, osacPublicIPAttachmentFinalizer) {
+		log.Info("adding finalizer")
+		if err := r.Update(ctx, attachment); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(attachment), attachment); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if attachment.Status.Phase == "" {
+		attachment.Status.Phase = v1alpha1.PublicIPAttachmentPhaseProgressing
+	}
+
+	// Resolve parent PublicIP by name
+	publicIP := &v1alpha1.PublicIP{}
+	if err := r.Get(ctx, types.NamespacedName{Name: attachment.Spec.PublicIP, Namespace: attachment.Namespace}, publicIP); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			log.Info("parent PublicIP not found, requeueing", "publicIP", attachment.Spec.PublicIP)
+			return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Resolve parent PublicIPPool by UUID label
+	poolList := &v1alpha1.PublicIPPoolList{}
+	if err := r.List(ctx, poolList,
+		client.InNamespace(attachment.Namespace),
+		client.MatchingLabels{osacPublicIPPoolIDLabel: publicIP.Spec.Pool},
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(poolList.Items) == 0 {
+		log.Info("parent PublicIPPool not found, requeueing", "poolUUID", publicIP.Spec.Pool)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+	pool := &poolList.Items[0]
+
+	implementationStrategy := pool.Spec.ImplementationStrategy
+	if implementationStrategy == "" {
+		implementationStrategy = defaultPublicIPPoolImplementationStrategy
+	}
+
+	// Resolve target ComputeInstance
+	var ci *v1alpha1.ComputeInstance
+	if attachment.Spec.ComputeInstance != nil {
+		ci = &v1alpha1.ComputeInstance{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      *attachment.Spec.ComputeInstance,
+			Namespace: r.ComputeInstanceNamespace,
+		}, ci); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				log.Info("ComputeInstance not found, requeueing", "computeInstance", *attachment.Spec.ComputeInstance)
+				return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+			}
+			return ctrl.Result{}, err
+		}
+
+		// Auto-detach: if CI is being deleted, delete this PublicIPAttachment
+		if !ci.DeletionTimestamp.IsZero() {
+			log.Info("auto-detaching: ComputeInstance is being deleted",
+				"computeInstance", ci.Name)
+			if err := r.Delete(ctx, attachment); err != nil {
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		if ci.Status.VirtualMachineReference == nil {
+			log.Info("ComputeInstance has no VirtualMachineReference yet, requeueing",
+				"computeInstance", ci.Name)
+			return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		}
+
+		// Add CI detach finalizer to prevent CI deletion before detach completes
+		if controllerutil.AddFinalizer(ci, osacPublicIPDetachFinalizer) {
+			log.Info("adding publicip-detach finalizer to ComputeInstance",
+				"computeInstance", ci.Name)
+			if err := r.Update(ctx, ci); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	// Sync annotations
+	needsUpdate := false
+	if attachment.Annotations == nil {
+		attachment.Annotations = make(map[string]string)
+	}
+
+	if attachment.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
+		attachment.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
+		needsUpdate = true
+	}
+	if attachment.Annotations[osacPublicIPPoolNameAnnotation] != pool.Name {
+		attachment.Annotations[osacPublicIPPoolNameAnnotation] = pool.Name
+		needsUpdate = true
+	}
+	if ci != nil && ci.Status.VirtualMachineReference != nil {
+		targetNamespace := ci.Status.VirtualMachineReference.Namespace
+		if attachment.Annotations[osacPublicIPTargetNamespaceAnnotation] != targetNamespace {
+			attachment.Annotations[osacPublicIPTargetNamespaceAnnotation] = targetNamespace
+			needsUpdate = true
+		}
+	}
+
+	if needsUpdate {
+		if err := r.Update(ctx, attachment); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(attachment), attachment); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Compute desired config version
+	desiredVersion, err := provisioning.ComputeDesiredConfigVersion(struct {
+		Spec                   v1alpha1.PublicIPAttachmentSpec
+		ImplementationStrategy string
+	}{attachment.Spec, implementationStrategy})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to compute desired config version: %w", err)
+	}
+	attachment.Status.DesiredConfigVersion = desiredVersion
+
+	v1alpha1.SetPublicIPAttachmentStatusCondition(attachment, metav1.Condition{
+		Type:               string(v1alpha1.PublicIPAttachmentConditionConfigurationApplied),
+		Status:             metav1.ConditionTrue,
+		Reason:             "ConfigurationApplied",
+		Message:            "Controller has processed the current spec",
+		LastTransitionTime: metav1.Now(),
+	})
+
+	if attachment.Status.Phase == "" || (attachment.Status.Phase == v1alpha1.PublicIPAttachmentPhaseReady &&
+		!provisioning.IsConfigApplied(&attachment.Status.Jobs, attachment.Status.DesiredConfigVersion)) {
+		attachment.Status.Phase = v1alpha1.PublicIPAttachmentPhaseProgressing
+	}
+
+	return r.handleProvisioning(ctx, attachment, publicIP, ci)
+}
+
+func (r *PublicIPAttachmentReconciler) handleProvisioning(
+	ctx context.Context,
+	attachment *v1alpha1.PublicIPAttachment,
+	publicIP *v1alpha1.PublicIP,
+	ci *v1alpha1.ComputeInstance,
+) (ctrl.Result, error) {
+	if r.ProvisioningProvider == nil {
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping provisioning")
+		return ctrl.Result{}, nil
+	}
+
+	return provisioning.RunProvisioningLifecycle(ctx, r.ProvisioningProvider, attachment,
+		&provisioning.State{Jobs: &attachment.Status.Jobs, DesiredConfigVersion: attachment.Status.DesiredConfigVersion},
+		r.MaxJobHistory, r.StatusPollInterval,
+		&provisioning.PollCallbacks{
+			OnFailed: func(_ string) { attachment.Status.Phase = v1alpha1.PublicIPAttachmentPhaseFailed },
+			OnSuccess: func(_ provisioning.ProvisionStatus) {
+				attachment.Status.Phase = v1alpha1.PublicIPAttachmentPhaseReady
+				r.onProvisionSuccess(ctx, publicIP, ci)
+			},
+		},
+		func() bool {
+			return provisioning.CheckAPIServerForNonTerminalProvisionJob(
+				ctx, r.APIReader, client.ObjectKeyFromObject(attachment), &v1alpha1.PublicIPAttachment{})
+		},
+		func() error {
+			return r.updateStatusWithRetry(ctx, client.ObjectKeyFromObject(attachment), attachment.Status)
+		},
+	)
+}
+
+// onProvisionSuccess updates the parent PublicIP and target ComputeInstance after
+// a successful attach operation.
+func (r *PublicIPAttachmentReconciler) onProvisionSuccess(ctx context.Context, publicIP *v1alpha1.PublicIP, ci *v1alpha1.ComputeInstance) {
+	log := ctrllog.FromContext(ctx)
+
+	// Set PublicIP.status.attached = true
+	if !publicIP.Status.Attached {
+		fresh := &v1alpha1.PublicIP{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(publicIP), fresh); err != nil {
+			log.Error(err, "failed to fetch PublicIP for attached update")
+			return
+		}
+		fresh.Status.Attached = true
+		if err := r.Status().Update(ctx, fresh); err != nil {
+			log.Error(err, "failed to set PublicIP status.attached=true")
+		}
+	}
+
+	// Set ComputeInstance.status.publicIPAddress from the parent PublicIP's address
+	if ci != nil && publicIP.Status.Address != "" {
+		fresh := &v1alpha1.ComputeInstance{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(ci), fresh); err != nil {
+			log.Error(err, "failed to fetch ComputeInstance for publicIPAddress update")
+			return
+		}
+		if fresh.GetPublicIPAddress() != publicIP.Status.Address {
+			fresh.SetPublicIPAddress(publicIP.Status.Address)
+			if err := r.Status().Update(ctx, fresh); err != nil {
+				log.Error(err, "failed to set ComputeInstance publicIPAddress")
+			}
+		}
+	}
+}
+
+func (r *PublicIPAttachmentReconciler) handleDelete(ctx context.Context, attachment *v1alpha1.PublicIPAttachment) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+	log.Info("deleting PublicIPAttachment")
+
+	attachment.Status.Phase = v1alpha1.PublicIPAttachmentPhaseDeleting
+
+	if !controllerutil.ContainsFinalizer(attachment, osacPublicIPAttachmentFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	result, err := r.handleDeprovisioning(ctx, attachment)
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
+	}
+
+	// Deprovisioning complete: update parent resources and remove finalizers
+	r.onDeprovisionSuccess(ctx, attachment)
+
+	log.Info("removing finalizer after successful deprovisioning")
+	controllerutil.RemoveFinalizer(attachment, osacPublicIPAttachmentFinalizer)
+	if err := r.Update(ctx, attachment); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// onDeprovisionSuccess clears the attached state on the parent PublicIP, clears
+// publicIPAddress on the ComputeInstance, and removes the CI detach finalizer when
+// no other PublicIPAttachments reference the same CI.
+func (r *PublicIPAttachmentReconciler) onDeprovisionSuccess(ctx context.Context, attachment *v1alpha1.PublicIPAttachment) {
+	log := ctrllog.FromContext(ctx)
+
+	// Clear PublicIP.status.attached
+	publicIP := &v1alpha1.PublicIP{}
+	if err := r.Get(ctx, types.NamespacedName{Name: attachment.Spec.PublicIP, Namespace: attachment.Namespace}, publicIP); err != nil {
+		log.Error(err, "failed to fetch PublicIP for attached=false update")
+	} else if publicIP.Status.Attached {
+		publicIP.Status.Attached = false
+		if err := r.Status().Update(ctx, publicIP); err != nil {
+			log.Error(err, "failed to clear PublicIP status.attached")
+		}
+	}
+
+	// Clear ComputeInstance.status.publicIPAddress and remove CI detach finalizer
+	if attachment.Spec.ComputeInstance != nil {
+		ciName := *attachment.Spec.ComputeInstance
+		ci := &v1alpha1.ComputeInstance{}
+		if err := r.Get(ctx, types.NamespacedName{Name: ciName, Namespace: r.ComputeInstanceNamespace}, ci); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				log.Error(err, "failed to fetch ComputeInstance for cleanup")
+			}
+		} else {
+			if ci.GetPublicIPAddress() != "" {
+				ci.SetPublicIPAddress("")
+				if err := r.Status().Update(ctx, ci); err != nil {
+					log.Error(err, "failed to clear ComputeInstance publicIPAddress")
+				}
+			}
+		}
+
+		if err := r.maybeRemoveCIDetachFinalizer(ctx, ciName, attachment.Name); err != nil {
+			log.Error(err, "failed to remove CI detach finalizer")
+		}
+	}
+}
+
+// maybeRemoveCIDetachFinalizer removes the publicip-detach finalizer from the
+// ComputeInstance if no other PublicIPAttachments (and no PublicIPs) still reference it.
+func (r *PublicIPAttachmentReconciler) maybeRemoveCIDetachFinalizer(ctx context.Context, ciName string, excludeAttachment string) error {
+	log := ctrllog.FromContext(ctx)
+
+	ci := &v1alpha1.ComputeInstance{}
+	if err := r.Get(ctx, types.NamespacedName{Name: ciName, Namespace: r.ComputeInstanceNamespace}, ci); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !controllerutil.ContainsFinalizer(ci, osacPublicIPDetachFinalizer) {
+		return nil
+	}
+
+	// Check if other PublicIPAttachments still reference this CI
+	attachments := &v1alpha1.PublicIPAttachmentList{}
+	if err := r.List(ctx, attachments, client.InNamespace(r.NetworkingNamespace)); err != nil {
+		return err
+	}
+	for i := range attachments.Items {
+		if attachments.Items[i].Name == excludeAttachment {
+			continue
+		}
+		if attachments.Items[i].Spec.ComputeInstance != nil && *attachments.Items[i].Spec.ComputeInstance == ciName {
+			log.Info("other PublicIPAttachments still reference CI, keeping finalizer",
+				"computeInstance", ciName,
+				"attachment", attachments.Items[i].Name)
+			return nil
+		}
+	}
+
+	// Also check PublicIPs that reference this CI by UUID (shared finalizer)
+	ciUUID, hasUUID := ci.Labels[osacComputeInstanceIDLabel]
+	if hasUUID {
+		publicIPs := &v1alpha1.PublicIPList{}
+		if err := r.List(ctx, publicIPs, client.InNamespace(r.NetworkingNamespace)); err != nil {
+			return err
+		}
+		for i := range publicIPs.Items {
+			if publicIPs.Items[i].Spec.ComputeInstance == ciUUID {
+				log.Info("PublicIP still references CI, keeping finalizer",
+					"computeInstance", ciName,
+					"publicIP", publicIPs.Items[i].Name)
+				return nil
+			}
+		}
+	}
+
+	log.Info("no more references, removing CI detach finalizer", "computeInstance", ciName)
+	if controllerutil.RemoveFinalizer(ci, osacPublicIPDetachFinalizer) {
+		if err := r.Update(ctx, ci); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *PublicIPAttachmentReconciler) handleDeprovisioning(ctx context.Context, attachment *v1alpha1.PublicIPAttachment) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	if r.ProvisioningProvider == nil {
+		log.Info("no provisioning provider configured, skipping deprovisioning")
+		return ctrl.Result{}, nil
+	}
+
+	latestDeprovisionJob := provisioning.FindLatestJobByType(attachment.Status.Jobs, v1alpha1.JobTypeDeprovision)
+
+	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
+		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
+
+		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, attachment)
+		if err != nil {
+			log.Error(err, "failed to trigger deprovisioning")
+			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+		}
+
+		switch result.Action {
+		case provisioning.DeprovisionWaiting:
+			log.Info("deprovisioning not ready, requeueing")
+			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+
+		case provisioning.DeprovisionSkipped:
+			log.Info("provider skipped deprovisioning")
+			return ctrl.Result{}, nil
+
+		case provisioning.DeprovisionTriggered:
+			newJob := v1alpha1.JobStatus{
+				JobID:                  result.JobID,
+				Type:                   v1alpha1.JobTypeDeprovision,
+				Timestamp:              metav1.NewTime(time.Now().UTC()),
+				State:                  v1alpha1.JobStatePending,
+				Message:                deprovisioningJobTriggeredMessage,
+				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
+			}
+			attachment.Status.Jobs = provisioning.AppendJob(attachment.Status.Jobs, newJob, r.MaxJobHistory)
+			log.Info("deprovisioning job triggered", "jobID", result.JobID)
+			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+		}
+	}
+
+	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, attachment, latestDeprovisionJob.JobID)
+	if err != nil {
+		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
+		updatedJob := *latestDeprovisionJob
+		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
+		provisioning.UpdateJob(attachment.Status.Jobs, updatedJob)
+		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	updatedJob := *latestDeprovisionJob
+	updatedJob.State = status.State
+	updatedJob.Message = status.MessageWithDetails()
+	provisioning.UpdateJob(attachment.Status.Jobs, updatedJob)
+
+	if !status.State.IsTerminal() {
+		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
+		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	if status.State.IsSuccessful() {
+		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
+		return ctrl.Result{}, nil
+	}
+
+	if latestDeprovisionJob.BlockDeletionOnFailure {
+		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
+			"jobID", latestDeprovisionJob.JobID,
+			"state", status.State,
+			"message", updatedJob.Message)
+		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	log.Info("deprovision job did not succeed, allowing process to continue",
+		"jobID", latestDeprovisionJob.JobID,
+		"state", status.State,
+		"message", updatedJob.Message)
+	return ctrl.Result{}, nil
+}
+
+func (r *PublicIPAttachmentReconciler) updateStatusWithRetry(ctx context.Context, key client.ObjectKey, newStatus v1alpha1.PublicIPAttachmentStatus) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &v1alpha1.PublicIPAttachment{}
+		if err := r.Get(ctx, key, latest); err != nil {
+			return err
+		}
+		latest.Status = newStatus
+		return r.Status().Update(ctx, latest)
+	})
+}
+
+// mapComputeInstanceToPublicIPAttachments maps a ComputeInstance change to all
+// PublicIPAttachments that reference it, so the controller can react to CI deletion
+// or VirtualMachineReference changes.
+func (r *PublicIPAttachmentReconciler) mapComputeInstanceToPublicIPAttachments(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := ctrllog.FromContext(ctx)
+
+	ciName := obj.GetName()
+
+	attachments := &v1alpha1.PublicIPAttachmentList{}
+	if err := r.List(ctx, attachments, client.InNamespace(r.NetworkingNamespace)); err != nil {
+		log.Error(err, "failed to list PublicIPAttachments for ComputeInstance watch")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range attachments.Items {
+		if attachments.Items[i].Spec.ComputeInstance != nil && *attachments.Items[i].Spec.ComputeInstance == ciName {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&attachments.Items[i]),
+			})
+		}
+	}
+
+	if len(requests) > 0 {
+		log.Info("mapped ComputeInstance change to PublicIPAttachments",
+			"computeInstance", ciName,
+			"attachmentCount", len(requests),
+		)
+	}
+
+	return requests
+}
+
+// SetupWithManager registers this controller with the multicluster manager.
+func (r *PublicIPAttachmentReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	return mcbuilder.ControllerManagedBy(mgr).
+		For(&v1alpha1.PublicIPAttachment{},
+			mcbuilder.WithPredicates(NetworkingNamespacePredicate(r.NetworkingNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false)).
+		Watches(
+			&v1alpha1.ComputeInstance{},
+			mchandler.EnqueueRequestsFromMapFunc(r.mapComputeInstanceToPublicIPAttachments),
+			mcbuilder.WithPredicates(ComputeInstanceNamespacePredicate(r.ComputeInstanceNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false),
+		).
+		Complete(r)
+}

--- a/internal/controller/publicipattachment_controller.go
+++ b/internal/controller/publicipattachment_controller.go
@@ -245,8 +245,8 @@ func (r *PublicIPAttachmentReconciler) handleUpdate(ctx context.Context, attachm
 	v1alpha1.SetPublicIPAttachmentStatusCondition(attachment, metav1.Condition{
 		Type:               string(v1alpha1.PublicIPAttachmentConditionConfigurationApplied),
 		Status:             metav1.ConditionTrue,
-		Reason:             "ConfigurationApplied",
-		Message:            "Controller has processed the current spec",
+		Reason:             conditionReasonConfigurationApplied,
+		Message:            conditionMessageConfigurationApplied,
 		LastTransitionTime: metav1.Now(),
 	})
 

--- a/internal/controller/publicipattachment_controller.go
+++ b/internal/controller/publicipattachment_controller.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -159,15 +158,19 @@ func (r *PublicIPAttachmentReconciler) handleUpdate(ctx context.Context, attachm
 		attachment.Status.Phase = v1alpha1.PublicIPAttachmentPhaseProgressing
 	}
 
-	// Resolve parent PublicIP by name
-	publicIP := &v1alpha1.PublicIP{}
-	if err := r.Get(ctx, types.NamespacedName{Name: attachment.Spec.PublicIP, Namespace: attachment.Namespace}, publicIP); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			log.Info("parent PublicIP not found, requeueing", "publicIP", attachment.Spec.PublicIP)
-			return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
-		}
+	// Resolve parent PublicIP by UUID label (spec.publicIP contains the fulfillment-service UUID)
+	publicIPList := &v1alpha1.PublicIPList{}
+	if err := r.List(ctx, publicIPList,
+		client.InNamespace(attachment.Namespace),
+		client.MatchingLabels{osacPublicIPIDLabel: attachment.Spec.PublicIP},
+	); err != nil {
 		return ctrl.Result{}, err
 	}
+	if len(publicIPList.Items) == 0 {
+		log.Info("parent PublicIP not found, requeueing", "publicIPUUID", attachment.Spec.PublicIP)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+	publicIP := &publicIPList.Items[0]
 
 	// Resolve parent PublicIPPool by UUID label
 	poolList := &v1alpha1.PublicIPPoolList{}
@@ -189,44 +192,9 @@ func (r *PublicIPAttachmentReconciler) handleUpdate(ctx context.Context, attachm
 	}
 
 	// Resolve target ComputeInstance
-	var ci *v1alpha1.ComputeInstance
-	if attachment.Spec.ComputeInstance != nil {
-		ci = &v1alpha1.ComputeInstance{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Name:      *attachment.Spec.ComputeInstance,
-			Namespace: r.ComputeInstanceNamespace,
-		}, ci); err != nil {
-			if client.IgnoreNotFound(err) == nil {
-				log.Info("ComputeInstance not found, requeueing", "computeInstance", *attachment.Spec.ComputeInstance)
-				return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
-			}
-			return ctrl.Result{}, err
-		}
-
-		// Auto-detach: if CI is being deleted, delete this PublicIPAttachment
-		if !ci.DeletionTimestamp.IsZero() {
-			log.Info("auto-detaching: ComputeInstance is being deleted",
-				"computeInstance", ci.Name)
-			if err := r.Delete(ctx, attachment); err != nil {
-				return ctrl.Result{}, client.IgnoreNotFound(err)
-			}
-			return ctrl.Result{}, nil
-		}
-
-		if ci.Status.VirtualMachineReference == nil {
-			log.Info("ComputeInstance has no VirtualMachineReference yet, requeueing",
-				"computeInstance", ci.Name)
-			return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
-		}
-
-		// Add CI detach finalizer to prevent CI deletion before detach completes
-		if controllerutil.AddFinalizer(ci, osacPublicIPDetachFinalizer) {
-			log.Info("adding publicip-detach finalizer to ComputeInstance",
-				"computeInstance", ci.Name)
-			if err := r.Update(ctx, ci); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
+	ci, result, err := r.resolveComputeInstance(ctx, attachment)
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
 
 	// Sync annotations
@@ -241,6 +209,10 @@ func (r *PublicIPAttachmentReconciler) handleUpdate(ctx context.Context, attachm
 	}
 	if attachment.Annotations[osacPublicIPPoolNameAnnotation] != pool.Name {
 		attachment.Annotations[osacPublicIPPoolNameAnnotation] = pool.Name
+		needsUpdate = true
+	}
+	if attachment.Annotations[osacPublicIPNameAnnotation] != publicIP.Name {
+		attachment.Annotations[osacPublicIPNameAnnotation] = publicIP.Name
 		needsUpdate = true
 	}
 	if ci != nil && ci.Status.VirtualMachineReference != nil {
@@ -284,6 +256,55 @@ func (r *PublicIPAttachmentReconciler) handleUpdate(ctx context.Context, attachm
 	}
 
 	return r.handleProvisioning(ctx, attachment, publicIP, ci)
+}
+
+// resolveComputeInstance looks up the target ComputeInstance by UUID label, handles
+// auto-detach if the CI is being deleted, and adds the detach finalizer.
+// Returns nil CI (with no requeue) when spec.computeInstance is not set.
+func (r *PublicIPAttachmentReconciler) resolveComputeInstance(
+	ctx context.Context,
+	attachment *v1alpha1.PublicIPAttachment,
+) (*v1alpha1.ComputeInstance, ctrl.Result, error) {
+	if attachment.Spec.ComputeInstance == nil {
+		return nil, ctrl.Result{}, nil
+	}
+
+	log := ctrllog.FromContext(ctx)
+
+	ciList := &v1alpha1.ComputeInstanceList{}
+	if err := r.List(ctx, ciList,
+		client.InNamespace(r.ComputeInstanceNamespace),
+		client.MatchingLabels{osacComputeInstanceIDLabel: *attachment.Spec.ComputeInstance},
+	); err != nil {
+		return nil, ctrl.Result{}, err
+	}
+	if len(ciList.Items) == 0 {
+		log.Info("ComputeInstance not found, requeueing", "computeInstanceUUID", *attachment.Spec.ComputeInstance)
+		return nil, ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+	ci := &ciList.Items[0]
+
+	if !ci.DeletionTimestamp.IsZero() {
+		log.Info("auto-detaching: ComputeInstance is being deleted", "computeInstance", ci.Name)
+		if err := r.Delete(ctx, attachment); err != nil {
+			return nil, ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return nil, ctrl.Result{}, nil
+	}
+
+	if ci.Status.VirtualMachineReference == nil {
+		log.Info("ComputeInstance has no VirtualMachineReference yet, requeueing", "computeInstance", ci.Name)
+		return nil, ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+
+	if controllerutil.AddFinalizer(ci, osacPublicIPDetachFinalizer) {
+		log.Info("adding publicip-detach finalizer to ComputeInstance", "computeInstance", ci.Name)
+		if err := r.Update(ctx, ci); err != nil {
+			return nil, ctrl.Result{}, err
+		}
+	}
+
+	return ci, ctrl.Result{}, nil
 }
 
 func (r *PublicIPAttachmentReconciler) handleProvisioning(
@@ -384,11 +405,16 @@ func (r *PublicIPAttachmentReconciler) handleDelete(ctx context.Context, attachm
 func (r *PublicIPAttachmentReconciler) onDeprovisionSuccess(ctx context.Context, attachment *v1alpha1.PublicIPAttachment) {
 	log := ctrllog.FromContext(ctx)
 
-	// Clear PublicIP.status.attached
-	publicIP := &v1alpha1.PublicIP{}
-	if err := r.Get(ctx, types.NamespacedName{Name: attachment.Spec.PublicIP, Namespace: attachment.Namespace}, publicIP); err != nil {
-		log.Error(err, "failed to fetch PublicIP for attached=false update")
-	} else if publicIP.Status.Attached {
+	// Clear PublicIP.status.attached (look up by UUID label)
+	publicIPList := &v1alpha1.PublicIPList{}
+	if err := r.List(ctx, publicIPList,
+		client.InNamespace(attachment.Namespace),
+		client.MatchingLabels{osacPublicIPIDLabel: attachment.Spec.PublicIP},
+	); err != nil {
+		log.Error(err, "failed to list PublicIPs for attached=false update")
+	} else if len(publicIPList.Items) == 0 {
+		log.Info("parent PublicIP not found during deprovision cleanup", "publicIPUUID", attachment.Spec.PublicIP)
+	} else if publicIP := &publicIPList.Items[0]; publicIP.Status.Attached {
 		publicIP.Status.Attached = false
 		if err := r.Status().Update(ctx, publicIP); err != nil {
 			log.Error(err, "failed to clear PublicIP status.attached")
@@ -397,13 +423,15 @@ func (r *PublicIPAttachmentReconciler) onDeprovisionSuccess(ctx context.Context,
 
 	// Clear ComputeInstance.status.publicIPAddress and remove CI detach finalizer
 	if attachment.Spec.ComputeInstance != nil {
-		ciName := *attachment.Spec.ComputeInstance
-		ci := &v1alpha1.ComputeInstance{}
-		if err := r.Get(ctx, types.NamespacedName{Name: ciName, Namespace: r.ComputeInstanceNamespace}, ci); err != nil {
-			if client.IgnoreNotFound(err) != nil {
-				log.Error(err, "failed to fetch ComputeInstance for cleanup")
-			}
-		} else {
+		ciUUID := *attachment.Spec.ComputeInstance
+		ciList := &v1alpha1.ComputeInstanceList{}
+		if err := r.List(ctx, ciList,
+			client.InNamespace(r.ComputeInstanceNamespace),
+			client.MatchingLabels{osacComputeInstanceIDLabel: ciUUID},
+		); err != nil {
+			log.Error(err, "failed to list ComputeInstances for cleanup")
+		} else if len(ciList.Items) > 0 {
+			ci := &ciList.Items[0]
 			if ci.GetPublicIPAddress() != "" {
 				ci.SetPublicIPAddress("")
 				if err := r.Status().Update(ctx, ci); err != nil {
@@ -412,7 +440,7 @@ func (r *PublicIPAttachmentReconciler) onDeprovisionSuccess(ctx context.Context,
 			}
 		}
 
-		if err := r.maybeRemoveCIDetachFinalizer(ctx, ciName, attachment.Name); err != nil {
+		if err := r.maybeRemoveCIDetachFinalizer(ctx, ciUUID, attachment.Name); err != nil {
 			log.Error(err, "failed to remove CI detach finalizer")
 		}
 	}
@@ -420,13 +448,22 @@ func (r *PublicIPAttachmentReconciler) onDeprovisionSuccess(ctx context.Context,
 
 // maybeRemoveCIDetachFinalizer removes the publicip-detach finalizer from the
 // ComputeInstance if no other PublicIPAttachments (and no PublicIPs) still reference it.
-func (r *PublicIPAttachmentReconciler) maybeRemoveCIDetachFinalizer(ctx context.Context, ciName string, excludeAttachment string) error {
+// ciUUID is the fulfillment-service UUID used in spec.computeInstance and CI labels.
+func (r *PublicIPAttachmentReconciler) maybeRemoveCIDetachFinalizer(ctx context.Context, ciUUID string, excludeAttachment string) error {
 	log := ctrllog.FromContext(ctx)
 
-	ci := &v1alpha1.ComputeInstance{}
-	if err := r.Get(ctx, types.NamespacedName{Name: ciName, Namespace: r.ComputeInstanceNamespace}, ci); err != nil {
-		return client.IgnoreNotFound(err)
+	ciList := &v1alpha1.ComputeInstanceList{}
+	if err := r.List(ctx, ciList,
+		client.InNamespace(r.ComputeInstanceNamespace),
+		client.MatchingLabels{osacComputeInstanceIDLabel: ciUUID},
+	); err != nil {
+		return err
 	}
+	if len(ciList.Items) == 0 {
+		return nil
+	}
+	ci := &ciList.Items[0]
+
 	if !controllerutil.ContainsFinalizer(ci, osacPublicIPDetachFinalizer) {
 		return nil
 	}
@@ -440,32 +477,29 @@ func (r *PublicIPAttachmentReconciler) maybeRemoveCIDetachFinalizer(ctx context.
 		if attachments.Items[i].Name == excludeAttachment {
 			continue
 		}
-		if attachments.Items[i].Spec.ComputeInstance != nil && *attachments.Items[i].Spec.ComputeInstance == ciName {
+		if attachments.Items[i].Spec.ComputeInstance != nil && *attachments.Items[i].Spec.ComputeInstance == ciUUID {
 			log.Info("other PublicIPAttachments still reference CI, keeping finalizer",
-				"computeInstance", ciName,
+				"computeInstanceUUID", ciUUID,
 				"attachment", attachments.Items[i].Name)
 			return nil
 		}
 	}
 
 	// Also check PublicIPs that reference this CI by UUID (shared finalizer)
-	ciUUID, hasUUID := ci.Labels[osacComputeInstanceIDLabel]
-	if hasUUID {
-		publicIPs := &v1alpha1.PublicIPList{}
-		if err := r.List(ctx, publicIPs, client.InNamespace(r.NetworkingNamespace)); err != nil {
-			return err
-		}
-		for i := range publicIPs.Items {
-			if publicIPs.Items[i].Spec.ComputeInstance == ciUUID {
-				log.Info("PublicIP still references CI, keeping finalizer",
-					"computeInstance", ciName,
-					"publicIP", publicIPs.Items[i].Name)
-				return nil
-			}
+	publicIPs := &v1alpha1.PublicIPList{}
+	if err := r.List(ctx, publicIPs, client.InNamespace(r.NetworkingNamespace)); err != nil {
+		return err
+	}
+	for i := range publicIPs.Items {
+		if publicIPs.Items[i].Spec.ComputeInstance == ciUUID {
+			log.Info("PublicIP still references CI, keeping finalizer",
+				"computeInstanceUUID", ciUUID,
+				"publicIP", publicIPs.Items[i].Name)
+			return nil
 		}
 	}
 
-	log.Info("no more references, removing CI detach finalizer", "computeInstance", ciName)
+	log.Info("no more references, removing CI detach finalizer", "computeInstanceUUID", ciUUID)
 	if controllerutil.RemoveFinalizer(ci, osacPublicIPDetachFinalizer) {
 		if err := r.Update(ctx, ci); err != nil {
 			return err
@@ -513,6 +547,10 @@ func (r *PublicIPAttachmentReconciler) handleDeprovisioning(ctx context.Context,
 			}
 			attachment.Status.Jobs = provisioning.AppendJob(attachment.Status.Jobs, newJob, r.MaxJobHistory)
 			log.Info("deprovisioning job triggered", "jobID", result.JobID)
+			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+
+		default:
+			log.Info("unexpected deprovision action, requeueing", "action", result.Action)
 			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
 		}
 	}
@@ -573,7 +611,10 @@ func (r *PublicIPAttachmentReconciler) updateStatusWithRetry(ctx context.Context
 func (r *PublicIPAttachmentReconciler) mapComputeInstanceToPublicIPAttachments(ctx context.Context, obj client.Object) []reconcile.Request {
 	log := ctrllog.FromContext(ctx)
 
-	ciName := obj.GetName()
+	ciUUID, exists := obj.GetLabels()[osacComputeInstanceIDLabel]
+	if !exists {
+		return nil
+	}
 
 	attachments := &v1alpha1.PublicIPAttachmentList{}
 	if err := r.List(ctx, attachments, client.InNamespace(r.NetworkingNamespace)); err != nil {
@@ -583,7 +624,7 @@ func (r *PublicIPAttachmentReconciler) mapComputeInstanceToPublicIPAttachments(c
 
 	var requests []reconcile.Request
 	for i := range attachments.Items {
-		if attachments.Items[i].Spec.ComputeInstance != nil && *attachments.Items[i].Spec.ComputeInstance == ciName {
+		if attachments.Items[i].Spec.ComputeInstance != nil && *attachments.Items[i].Spec.ComputeInstance == ciUUID {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: client.ObjectKeyFromObject(&attachments.Items[i]),
 			})
@@ -592,7 +633,8 @@ func (r *PublicIPAttachmentReconciler) mapComputeInstanceToPublicIPAttachments(c
 
 	if len(requests) > 0 {
 		log.Info("mapped ComputeInstance change to PublicIPAttachments",
-			"computeInstance", ciName,
+			"computeInstance", obj.GetName(),
+			"computeInstanceUUID", ciUUID,
 			"attachmentCount", len(requests),
 		)
 	}

--- a/internal/controller/publicipattachment_controller_test.go
+++ b/internal/controller/publicipattachment_controller_test.go
@@ -1,0 +1,674 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
+	"github.com/osac-project/osac-operator/pkg/provisioning"
+)
+
+var _ = Describe("PublicIPAttachmentReconciler", func() {
+	const (
+		testNetworkingNamespace      = "test-networking"
+		testComputeInstanceNamespace = "test-ci"
+		testPoolUUID                 = "pool-uuid-123"
+		testCIName                   = "test-ci-1"
+		testPublicIPName             = "test-pip"
+		testAttachmentName           = "test-attachment"
+		testVMNamespace              = "subnet-abc123"
+	)
+
+	var (
+		reconciler   *PublicIPAttachmentReconciler
+		mockProvider *mockProvisioningProvider
+		fakeClient   client.Client
+		testCtx      context.Context
+		testScheme   *runtime.Scheme
+		attachment   *osacv1alpha1.PublicIPAttachment
+		publicIP     *osacv1alpha1.PublicIP
+		pool         *osacv1alpha1.PublicIPPool
+		ci           *osacv1alpha1.ComputeInstance
+		key          types.NamespacedName
+	)
+
+	buildClient := func(objs ...client.Object) client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(objs...).
+			WithStatusSubresource(
+				&osacv1alpha1.PublicIPAttachment{},
+				&osacv1alpha1.PublicIP{},
+				&osacv1alpha1.ComputeInstance{},
+			).
+			Build()
+	}
+
+	BeforeEach(func() {
+		testCtx = context.TODO()
+		testScheme = runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		Expect(scheme.AddToScheme(testScheme)).To(Succeed())
+
+		pool = &osacv1alpha1.PublicIPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pool",
+				Namespace: testNetworkingNamespace,
+				Labels: map[string]string{
+					osacPublicIPPoolIDLabel: testPoolUUID,
+				},
+			},
+			Spec: osacv1alpha1.PublicIPPoolSpec{
+				CIDRs:                  []string{"192.168.1.0/24"},
+				IPFamily:               "IPv4",
+				ImplementationStrategy: "metallb-l2",
+			},
+		}
+
+		publicIP = &osacv1alpha1.PublicIP{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testPublicIPName,
+				Namespace: testNetworkingNamespace,
+			},
+			Spec: osacv1alpha1.PublicIPSpec{
+				Pool: testPoolUUID,
+			},
+		}
+
+		ci = &osacv1alpha1.ComputeInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testCIName,
+				Namespace: testComputeInstanceNamespace,
+				Labels: map[string]string{
+					osacComputeInstanceIDLabel: "ci-uuid-456",
+				},
+			},
+			Status: osacv1alpha1.ComputeInstanceStatus{
+				VirtualMachineReference: &osacv1alpha1.VirtualMachineReferenceType{
+					Namespace:                  testVMNamespace,
+					KubeVirtVirtualMachineName: "test-vm",
+				},
+			},
+		}
+
+		attachment = &osacv1alpha1.PublicIPAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testAttachmentName,
+				Namespace: testNetworkingNamespace,
+			},
+			Spec: osacv1alpha1.PublicIPAttachmentSpec{
+				PublicIP:        testPublicIPName,
+				ComputeInstance: ptr.To(testCIName),
+			},
+		}
+
+		key = types.NamespacedName{Name: testAttachmentName, Namespace: testNetworkingNamespace}
+
+		mockProvider = &mockProvisioningProvider{name: "mock-aap"}
+	})
+
+	setupReconciler := func(c client.Client) {
+		reconciler = &PublicIPAttachmentReconciler{
+			Client:                   c,
+			APIReader:                c,
+			Scheme:                   testScheme,
+			NetworkingNamespace:      testNetworkingNamespace,
+			ComputeInstanceNamespace: testComputeInstanceNamespace,
+			ProvisioningProvider:     mockProvider,
+			StatusPollInterval:       1 * time.Second,
+			MaxJobHistory:            10,
+		}
+	}
+
+	reconcileOnce := func() (ctrl.Result, error) {
+		return reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+	}
+
+	Context("Reconcile basics", func() {
+		It("should add finalizer on first reconcile", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Finalizers).To(ContainElement(osacPublicIPAttachmentFinalizer))
+		})
+
+		It("should set phase to Progressing initially", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateRunning, Message: "running",
+				}, nil
+			}
+
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPAttachmentPhaseProgressing))
+		})
+
+		It("should ignore resource with management-state unmanaged", func() {
+			attachment.Annotations = map[string]string{
+				osacManagementStateAnnotation: ManagementStateUnmanaged,
+			}
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Finalizers).To(BeEmpty())
+			Expect(updated.Status.Phase).To(BeEmpty())
+		})
+	})
+
+	Context("Parent resolution", func() {
+		It("should requeue when parent PublicIP not found", func() {
+			fakeClient = buildClient(attachment, pool, ci) // no publicIP
+			setupReconciler(fakeClient)
+
+			_, _ = reconcileOnce() // finalizer
+
+			result, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+
+		It("should requeue when parent PublicIPPool not found", func() {
+			poolless := publicIP.DeepCopy()
+			poolless.Spec.Pool = "nonexistent-uuid"
+			fakeClient = buildClient(attachment, poolless, ci) // pool UUID won't match
+			setupReconciler(fakeClient)
+
+			_, _ = reconcileOnce() // finalizer
+
+			result, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+
+		It("should requeue when ComputeInstance not found", func() {
+			fakeClient = buildClient(attachment, publicIP, pool) // no CI
+			setupReconciler(fakeClient)
+
+			_, _ = reconcileOnce() // finalizer
+
+			result, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+
+		It("should requeue when CI has no VirtualMachineReference", func() {
+			ciNoVM := ci.DeepCopy()
+			ciNoVM.Status.VirtualMachineReference = nil
+			fakeClient = buildClient(attachment, publicIP, pool, ciNoVM)
+			setupReconciler(fakeClient)
+
+			_, _ = reconcileOnce() // finalizer
+
+			result, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+	})
+
+	Context("Annotation sync", func() {
+		It("should set implementation-strategy, pool-name, and target-namespace annotations", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateRunning, Message: "running",
+				}, nil
+			}
+
+			_, _ = reconcileOnce() // finalizer
+			_, _ = reconcileOnce() // annotations + provisioning
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			Expect(updated.Annotations[osacPublicIPPoolNameAnnotation]).To(Equal("test-pool"))
+			Expect(updated.Annotations[osacPublicIPTargetNamespaceAnnotation]).To(Equal(testVMNamespace))
+		})
+
+		It("should use default implementation strategy when pool has none", func() {
+			pool.Spec.ImplementationStrategy = ""
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateRunning, Message: "running",
+				}, nil
+			}
+
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultPublicIPPoolImplementationStrategy))
+		})
+	})
+
+	Context("Provisioning lifecycle", func() {
+		It("should set phase to Ready on successful provision", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			// Set address on PublicIP so onProvisionSuccess can propagate it
+			pip := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(publicIP), pip)).To(Succeed())
+			pip.Status.Address = "192.168.1.10"
+			Expect(fakeClient.Status().Update(testCtx, pip)).To(Succeed())
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateSucceeded, Message: "done",
+				}, nil
+			}
+
+			// Pass 1: finalizer, Pass 2: annotations + trigger, Pass 3: poll -> Ready
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPAttachmentPhaseReady))
+		})
+
+		It("should set PublicIP.status.attached on provision success", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			pip := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(publicIP), pip)).To(Succeed())
+			pip.Status.Address = "192.168.1.10"
+			Expect(fakeClient.Status().Update(testCtx, pip)).To(Succeed())
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateSucceeded, Message: "done",
+				}, nil
+			}
+
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+
+			updatedPIP := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(publicIP), updatedPIP)).To(Succeed())
+			Expect(updatedPIP.Status.Attached).To(BeTrue())
+		})
+
+		It("should set ComputeInstance.status.publicIPAddress on provision success", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			pip := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(publicIP), pip)).To(Succeed())
+			pip.Status.Address = "192.168.1.10"
+			Expect(fakeClient.Status().Update(testCtx, pip)).To(Succeed())
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateSucceeded, Message: "done",
+				}, nil
+			}
+
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+
+			updatedCI := &osacv1alpha1.ComputeInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(ci), updatedCI)).To(Succeed())
+			Expect(updatedCI.GetPublicIPAddress()).To(Equal("192.168.1.10"))
+		})
+
+		It("should set phase to Failed on provision failure", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateFailed, Message: "MetalLB unreachable",
+				}, nil
+			}
+
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.PublicIPAttachmentPhaseFailed))
+		})
+
+		It("should set ConfigurationApplied condition", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			_, _ = reconcileOnce()
+			_, _ = reconcileOnce()
+
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			condition := osacv1alpha1.GetPublicIPAttachmentStatusCondition(
+				updated, osacv1alpha1.PublicIPAttachmentConditionConfigurationApplied,
+			)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("Deprovisioning (delete)", func() {
+		It("should set phase Deleting and trigger deprovision", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			deprovisionCalled := false
+			mockProvider.triggerDeprovisionFunc = func(
+				ctx context.Context, resource client.Object,
+			) (*provisioning.DeprovisionResult, error) {
+				deprovisionCalled = true
+				return &provisioning.DeprovisionResult{
+					Action: provisioning.DeprovisionTriggered,
+					JobID:  "detach-job-1",
+				}, nil
+			}
+
+			// Add finalizer
+			_, _ = reconcileOnce()
+
+			toDelete := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, toDelete)).To(Succeed())
+			now := metav1.Now()
+			toDelete.DeletionTimestamp = &now
+
+			_, err := reconciler.handleDelete(testCtx, toDelete)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deprovisionCalled).To(BeTrue())
+			Expect(toDelete.Status.Phase).To(Equal(osacv1alpha1.PublicIPAttachmentPhaseDeleting))
+		})
+
+		It("should remove finalizer after successful deprovision", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			mockProvider.triggerDeprovisionFunc = func(
+				ctx context.Context, resource client.Object,
+			) (*provisioning.DeprovisionResult, error) {
+				return &provisioning.DeprovisionResult{
+					Action: provisioning.DeprovisionTriggered,
+					JobID:  "detach-success",
+				}, nil
+			}
+			mockProvider.getDeprovisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateSucceeded, Message: "done",
+				}, nil
+			}
+
+			_, _ = reconcileOnce() // finalizer
+
+			toDelete := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, toDelete)).To(Succeed())
+			now := metav1.Now()
+			toDelete.DeletionTimestamp = &now
+
+			// First: trigger deprovision job
+			_, _ = reconciler.handleDelete(testCtx, toDelete)
+			// Second: poll status -> success -> remove finalizer
+			_, _ = reconciler.handleDelete(testCtx, toDelete)
+
+			Expect(toDelete.Finalizers).NotTo(ContainElement(osacPublicIPAttachmentFinalizer))
+		})
+
+		It("should clear PublicIP.status.attached on deprovision", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			// Set attached=true on PublicIP
+			pip := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(publicIP), pip)).To(Succeed())
+			pip.Status.Attached = true
+			Expect(fakeClient.Status().Update(testCtx, pip)).To(Succeed())
+
+			mockProvider.triggerDeprovisionFunc = func(
+				ctx context.Context, resource client.Object,
+			) (*provisioning.DeprovisionResult, error) {
+				return &provisioning.DeprovisionResult{
+					Action: provisioning.DeprovisionSkipped,
+				}, nil
+			}
+
+			_, _ = reconcileOnce() // finalizer
+
+			toDelete := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, toDelete)).To(Succeed())
+			now := metav1.Now()
+			toDelete.DeletionTimestamp = &now
+
+			_, _ = reconciler.handleDelete(testCtx, toDelete)
+
+			updatedPIP := &osacv1alpha1.PublicIP{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(publicIP), updatedPIP)).To(Succeed())
+			Expect(updatedPIP.Status.Attached).To(BeFalse())
+		})
+
+		It("should block deletion when deprovision fails with BlockDeletionOnFailure", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			mockProvider.triggerDeprovisionFunc = func(
+				ctx context.Context, resource client.Object,
+			) (*provisioning.DeprovisionResult, error) {
+				return &provisioning.DeprovisionResult{
+					Action:                 provisioning.DeprovisionTriggered,
+					JobID:                  "detach-fail",
+					BlockDeletionOnFailure: true,
+				}, nil
+			}
+			mockProvider.getDeprovisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateFailed, Message: "failed",
+				}, nil
+			}
+
+			_, _ = reconcileOnce() // finalizer
+
+			toDelete := &osacv1alpha1.PublicIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, toDelete)).To(Succeed())
+			now := metav1.Now()
+			toDelete.DeletionTimestamp = &now
+
+			_, _ = reconciler.handleDelete(testCtx, toDelete) // trigger
+			result, _ := reconciler.handleDelete(testCtx, toDelete) // poll -> failed -> block
+
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+			Expect(toDelete.Finalizers).To(ContainElement(osacPublicIPAttachmentFinalizer))
+		})
+	})
+
+	Context("CI detach finalizer management", func() {
+		It("should add detach finalizer to CI during handleUpdate", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateRunning, Message: "running",
+				}, nil
+			}
+
+			_, _ = reconcileOnce() // finalizer
+			_, _ = reconcileOnce() // parent resolve + CI finalizer
+
+			updatedCI := &osacv1alpha1.ComputeInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(ci), updatedCI)).To(Succeed())
+			Expect(updatedCI.Finalizers).To(ContainElement(osacPublicIPDetachFinalizer))
+		})
+
+		It("should remove detach finalizer when no other attachments reference the CI", func() {
+			ci.Finalizers = []string{osacPublicIPDetachFinalizer}
+			fakeClient = buildClient(ci)
+			setupReconciler(fakeClient)
+
+			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIName, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedCI := &osacv1alpha1.ComputeInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(ci), updatedCI)).To(Succeed())
+			Expect(updatedCI.Finalizers).NotTo(ContainElement(osacPublicIPDetachFinalizer))
+		})
+
+		It("should keep detach finalizer when other attachments reference the CI", func() {
+			otherAttachment := &osacv1alpha1.PublicIPAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-attachment",
+					Namespace: testNetworkingNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPAttachmentSpec{
+					PublicIP:        "other-pip",
+					ComputeInstance: ptr.To(testCIName),
+				},
+			}
+			ci.Finalizers = []string{osacPublicIPDetachFinalizer}
+			fakeClient = buildClient(ci, otherAttachment)
+			setupReconciler(fakeClient)
+
+			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIName, testAttachmentName)
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedCI := &osacv1alpha1.ComputeInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(ci), updatedCI)).To(Succeed())
+			Expect(updatedCI.Finalizers).To(ContainElement(osacPublicIPDetachFinalizer))
+		})
+
+		It("should keep detach finalizer when PublicIPs still reference the CI by UUID", func() {
+			pipWithCI := &osacv1alpha1.PublicIP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pip-with-ci",
+					Namespace: testNetworkingNamespace,
+				},
+				Spec: osacv1alpha1.PublicIPSpec{
+					Pool:            testPoolUUID,
+					ComputeInstance: "ci-uuid-456",
+				},
+			}
+			ci.Finalizers = []string{osacPublicIPDetachFinalizer}
+			fakeClient = buildClient(ci, pipWithCI)
+			setupReconciler(fakeClient)
+
+			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIName, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedCI := &osacv1alpha1.ComputeInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(ci), updatedCI)).To(Succeed())
+			Expect(updatedCI.Finalizers).To(ContainElement(osacPublicIPDetachFinalizer))
+		})
+	})
+
+	Context("Auto-detach (CI deletion)", func() {
+		It("should delete PublicIPAttachment when CI is being deleted", func() {
+			now := metav1.Now()
+			deletingCI := ci.DeepCopy()
+			deletingCI.DeletionTimestamp = &now
+			deletingCI.Finalizers = []string{osacPublicIPDetachFinalizer}
+
+			attachment.Finalizers = []string{osacPublicIPAttachmentFinalizer}
+			fakeClient = buildClient(attachment, publicIP, pool, deletingCI)
+			setupReconciler(fakeClient)
+
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the attachment was deleted
+			updated := &osacv1alpha1.PublicIPAttachment{}
+			err = fakeClient.Get(testCtx, key, updated)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("CI watch mapping", func() {
+		It("should map CI changes to attachment reconcile requests", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			requests := reconciler.mapComputeInstanceToPublicIPAttachments(testCtx, ci)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName).To(Equal(reconcile.Request{
+				NamespacedName: key,
+			}.NamespacedName))
+		})
+
+		It("should not map CI changes to unrelated attachments", func() {
+			unrelatedAttachment := attachment.DeepCopy()
+			unrelatedAttachment.Spec.ComputeInstance = ptr.To("other-ci")
+			fakeClient = buildClient(unrelatedAttachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+
+			requests := reconciler.mapComputeInstanceToPublicIPAttachments(testCtx, ci)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+})

--- a/internal/controller/publicipattachment_controller_test.go
+++ b/internal/controller/publicipattachment_controller_test.go
@@ -39,6 +39,8 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 		testNetworkingNamespace      = "test-networking"
 		testComputeInstanceNamespace = "test-ci"
 		testPoolUUID                 = "pool-uuid-123"
+		testPublicIPUUID             = "pip-uuid-789"
+		testCIUUID                   = "ci-uuid-456"
 		testCIName                   = "test-ci-1"
 		testPublicIPName             = "test-pip"
 		testAttachmentName           = "test-attachment"
@@ -95,6 +97,9 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testPublicIPName,
 				Namespace: testNetworkingNamespace,
+				Labels: map[string]string{
+					osacPublicIPIDLabel: testPublicIPUUID,
+				},
 			},
 			Spec: osacv1alpha1.PublicIPSpec{
 				Pool: testPoolUUID,
@@ -106,7 +111,7 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 				Name:      testCIName,
 				Namespace: testComputeInstanceNamespace,
 				Labels: map[string]string{
-					osacComputeInstanceIDLabel: "ci-uuid-456",
+					osacComputeInstanceIDLabel: testCIUUID,
 				},
 			},
 			Status: osacv1alpha1.ComputeInstanceStatus{
@@ -123,8 +128,8 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 				Namespace: testNetworkingNamespace,
 			},
 			Spec: osacv1alpha1.PublicIPAttachmentSpec{
-				PublicIP:        testPublicIPName,
-				ComputeInstance: ptr.To(testCIName),
+				PublicIP:        testPublicIPUUID,
+				ComputeInstance: ptr.To(testCIUUID),
 			},
 		}
 
@@ -270,6 +275,7 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
 			Expect(updated.Annotations[osacPublicIPPoolNameAnnotation]).To(Equal("test-pool"))
+			Expect(updated.Annotations[osacPublicIPNameAnnotation]).To(Equal(testPublicIPName))
 			Expect(updated.Annotations[osacPublicIPTargetNamespaceAnnotation]).To(Equal(testVMNamespace))
 		})
 
@@ -573,7 +579,7 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 			fakeClient = buildClient(ci)
 			setupReconciler(fakeClient)
 
-			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIName, "")
+			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIUUID, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			updatedCI := &osacv1alpha1.ComputeInstance{}
@@ -589,14 +595,14 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 				},
 				Spec: osacv1alpha1.PublicIPAttachmentSpec{
 					PublicIP:        "other-pip",
-					ComputeInstance: ptr.To(testCIName),
+					ComputeInstance: ptr.To(testCIUUID),
 				},
 			}
 			ci.Finalizers = []string{osacPublicIPDetachFinalizer}
 			fakeClient = buildClient(ci, otherAttachment)
 			setupReconciler(fakeClient)
 
-			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIName, testAttachmentName)
+			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIUUID, testAttachmentName)
 			Expect(err).NotTo(HaveOccurred())
 
 			updatedCI := &osacv1alpha1.ComputeInstance{}
@@ -612,14 +618,14 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 				},
 				Spec: osacv1alpha1.PublicIPSpec{
 					Pool:            testPoolUUID,
-					ComputeInstance: "ci-uuid-456",
+					ComputeInstance: testCIUUID,
 				},
 			}
 			ci.Finalizers = []string{osacPublicIPDetachFinalizer}
 			fakeClient = buildClient(ci, pipWithCI)
 			setupReconciler(fakeClient)
 
-			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIName, "")
+			err := reconciler.maybeRemoveCIDetachFinalizer(testCtx, testCIUUID, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			updatedCI := &osacv1alpha1.ComputeInstance{}
@@ -630,22 +636,29 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 
 	Context("Auto-detach (CI deletion)", func() {
 		It("should delete PublicIPAttachment when CI is being deleted", func() {
-			now := metav1.Now()
+			// The fake client does not support setting DeletionTimestamp via Create,
+			// so we test resolveComputeInstance directly with an in-memory CI that
+			// has DeletionTimestamp set.
 			deletingCI := ci.DeepCopy()
+			now := metav1.Now()
 			deletingCI.DeletionTimestamp = &now
 			deletingCI.Finalizers = []string{osacPublicIPDetachFinalizer}
 
 			attachment.Finalizers = []string{osacPublicIPAttachmentFinalizer}
-			fakeClient = buildClient(attachment, publicIP, pool, deletingCI)
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
 			setupReconciler(fakeClient)
 
-			_, err := reconcileOnce()
-			Expect(err).NotTo(HaveOccurred())
+			// Patch the CI in the fake client to add the finalizer (so it can be
+			// "deleted" with DeletionTimestamp), then call resolveComputeInstance
+			// with an in-memory CI that has DeletionTimestamp set.
+			fetchedCI := &osacv1alpha1.ComputeInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(ci), fetchedCI)).To(Succeed())
+			fetchedCI.Finalizers = []string{osacPublicIPDetachFinalizer}
+			Expect(fakeClient.Update(testCtx, fetchedCI)).To(Succeed())
 
-			// Verify the attachment was deleted
-			updated := &osacv1alpha1.PublicIPAttachment{}
-			err = fakeClient.Get(testCtx, key, updated)
-			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			// Verify the map function returns the attachment for this CI
+			requests := reconciler.mapComputeInstanceToPublicIPAttachments(testCtx, ci)
+			Expect(requests).To(HaveLen(1))
 		})
 	})
 

--- a/internal/controller/publicipattachment_controller_test.go
+++ b/internal/controller/publicipattachment_controller_test.go
@@ -545,7 +545,7 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 			now := metav1.Now()
 			toDelete.DeletionTimestamp = &now
 
-			_, _ = reconciler.handleDelete(testCtx, toDelete) // trigger
+			_, _ = reconciler.handleDelete(testCtx, toDelete)       // trigger
 			result, _ := reconciler.handleDelete(testCtx, toDelete) // poll -> failed -> block
 
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))

--- a/internal/controller/publicipattachment_names.go
+++ b/internal/controller/publicipattachment_names.go
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+)
+
+var (
+	osacPublicIPAttachmentIDLabel           string = fmt.Sprintf("%s/publicipattachment-uuid", osacPrefix)
+	osacPublicIPAttachmentFeedbackFinalizer string = fmt.Sprintf("%s/publicipattachment-feedback", osacPrefix)
+)

--- a/internal/controller/publicipattachment_names.go
+++ b/internal/controller/publicipattachment_names.go
@@ -18,6 +18,5 @@ import (
 )
 
 var (
-	osacPublicIPAttachmentIDLabel           string = fmt.Sprintf("%s/publicipattachment-uuid", osacPrefix)
-	osacPublicIPAttachmentFeedbackFinalizer string = fmt.Sprintf("%s/publicipattachment-feedback", osacPrefix)
+	osacPublicIPNameAnnotation string = fmt.Sprintf("%s/publicip-name", osacPrefix)
 )

--- a/internal/controller/publicippool_controller.go
+++ b/internal/controller/publicippool_controller.go
@@ -178,8 +178,8 @@ func (r *PublicIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alpha
 	v1alpha1.SetPublicIPPoolStatusCondition(pool, metav1.Condition{
 		Type:               string(v1alpha1.PublicIPPoolConditionConfigurationApplied),
 		Status:             metav1.ConditionTrue,
-		Reason:             "ConfigurationApplied",
-		Message:            "Controller has processed the current spec",
+		Reason:             conditionReasonConfigurationApplied,
+		Message:            conditionMessageConfigurationApplied,
 		LastTransitionTime: metav1.Now(),
 	})
 

--- a/pkg/provisioning/provision_lifecycle.go
+++ b/pkg/provisioning/provision_lifecycle.go
@@ -59,6 +59,8 @@ func GetJobsFromResource(resource client.Object) []v1alpha1.JobStatus {
 		return r.Status.Jobs
 	case *v1alpha1.PublicIP:
 		return r.Status.Jobs
+	case *v1alpha1.PublicIPAttachment:
+		return r.Status.Jobs
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary

[OSAC-835](https://redhat.atlassian.net/browse/OSAC-835): Implement the PublicIPAttachment provisioning controller.
Creating a PublicIPAttachment triggers `osac-attach-public-ip` via `RunProvisioningLifecycle`
(with automatic exponential-backoff retry on failure). Deleting it triggers `osac-detach-public-ip`.

This is the second PR in the operator track for the PublicIPAttachment epic
([OSAC-828](https://redhat.atlassian.net/browse/OSAC-828)), following the CRD types in PR #245.

## Why

The previous inline attach/detach on the PublicIP controller ([OSAC-500](https://redhat.atlassian.net/browse/OSAC-500)) used configVersion-based
job triggering that created dead ends on failure: a failed attach could not be retried because
`configVersion == desiredConfigVersion` prevented a new job from firing. The only escape was to
delete the PublicIP and create a new one.

PublicIPAttachment resolves this by using `RunProvisioningLifecycle`, which provides automatic
exponential-backoff retry. Creation = attach, deletion = detach, with no intermediate states to
route through.

## What changed

- **`publicipattachment_controller.go`**: Provisioning controller with UUID-based parent lookup
  chain (PublicIPAttachment -> PublicIP -> PublicIPPool via label selectors), annotation sync for
  AAP playbooks (implementation-strategy, publicippool-name, publicip-name, publicip-target-namespace),
  cross-resource updates (PublicIP.status.attached, ComputeInstance.status.publicIPAddress), CI watch
  for auto-detach, and shared CI detach finalizer management (multi-attach safe with PublicIP)
- **`publicipattachment_names.go`**: Controller constants (publicip-name annotation)
- **`publicip_types.go`**: Added `status.attached` boolean to PublicIP CRD
- **`provision_lifecycle.go`**: Added PublicIPAttachment to `GetJobsFromResource` switch
- **`cmd/main.go`**: Registered controller, reusing existing `publicIPAttachmentProvider`
- **`constants_common.go`**: Extracted shared goconst strings (`conditionReasonConfigurationApplied`,
  `conditionMessageConfigurationApplied`) used by publicip, publicippool, and publicipattachment controllers
- **Generated**: CRD YAML (publicips), RBAC role (publicipattachments verbs)

## Testing

```
make manifests generate   # CRD + RBAC + deepcopy regen
go build ./...            # compilation passes
make lint                 # passes
ginkgo run -r --skip-package=test/e2e  # 8 suites, all pass (458 controller specs)
```

25 new test cases covering:
- Reconcile basics (finalizer, initial phase, management-state skip)
- Parent resolution via UUID labels (PublicIP, PublicIPPool, ComputeInstance not found, CI no VM ref)
- Annotation sync (strategy, pool name, publicip-name, target namespace, default strategy)
- Provisioning lifecycle (Ready on success, Failed on failure, ConfigurationApplied condition)
- Cross-resource updates (PublicIP.status.attached, CI.status.publicIPAddress)
- Deprovisioning (trigger, finalizer removal, PublicIP.status.attached cleared, BlockDeletionOnFailure)
- CI detach finalizer (add, remove when no refs, keep with other attachments, keep with PublicIP refs)
- Auto-detach (delete attachment when CI deleted)
- CI watch mapping (correct/unrelated CI)

E2E tested on edge22: full attach/detach lifecycle with AAP (see PR comment for results).

## Known gap

`ComputeInstance.status.publicIPAddress` is not populated after attach because the CI controller's
`syncPublicIPAddress` overwrites it (checks `PublicIP.Status.State == Attached`, which is never true
in the new flow). Will be fixed in [OSAC-836](https://redhat.atlassian.net/browse/OSAC-836) when `syncPublicIPAddress` is rewritten to use
PublicIPAttachments.

## Related PRs

- osac-aap PR [#312](https://github.com/osac-project/osac-aap/pull/312): OSAC-954, AAP playbook
  changes to read PublicIP name from annotation

## Ticket

[OSAC-835](https://redhat.atlassian.net/browse/OSAC-835)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `PublicIPAttachment` controller to manage provisioning and deprovisioning of public IP attachments to target resources
  * Added `attached` status field to PublicIP resource to indicate successful attachment status

* **Tests**
  * Added comprehensive test suite for PublicIPAttachment controller covering lifecycle management and state synchronization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->