### PR TITLE
OSAC-360: migrate to Red Hat hardened images with Go 1.26

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,8 +22,7 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o console-proxy cmd/console-proxy/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# Use Red Hat hardened core-runtime as minimal base image to package the binaries
 FROM registry.access.redhat.com/hi/core-runtime:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager and console-proxy binaries
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager and console-proxy binaries
-FROM golang:1.26 AS builder
+FROM registry.access.redhat.com/hi/go:1.26-builder AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o co
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/hi/core-runtime:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/console-proxy .


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.25 to 1.26 in the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->