### PR TITLE
OSAC-360: use ubi10/go-toolset:1.26 builder and ubi10-minimal:10.2 runtime

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,9 @@
 # Build the manager and console-proxy binaries
-FROM golang:1.25 AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
-WORKDIR /workspace
+WORKDIR /opt/app-root/src
 # Copy the Go Modules manifests (including the nested api module)
 COPY go.mod go.sum ./
 COPY api/go.mod api/go.sum api/
@@ -22,12 +22,8 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o console-proxy cmd/console-proxy/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
-COPY --from=builder /workspace/console-proxy .
-USER 65532:65532
-
-ENTRYPOINT ["/manager"]
+FROM registry.access.redhat.com/ubi10-minimal:10.2
+COPY --from=builder /opt/app-root/src/manager /usr/local/bin/
+COPY --from=builder /opt/app-root/src/console-proxy /usr/local/bin/
+USER 1001
+ENTRYPOINT ["/usr/local/bin/manager"]

--- a/config/console-proxy/deployment.yaml
+++ b/config/console-proxy/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         image: console-proxy
         imagePullPolicy: Always
         command:
-        - /console-proxy
+        - /usr/local/bin/console-proxy
         args:
         - --port=8443
         - --health-probe-bind-address=:8081

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
         #   type: RuntimeDefault
       containers:
       - command:
-        - /manager
+        - /usr/local/bin/manager
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081


### PR DESCRIPTION
Replace default images with publicly available UBI 10 equivalents:

- Builder: `registry.access.redhat.com/ubi10/go-toolset:1.26` (Go 1.26 pre-installed)
- Runtime: `registry.access.redhat.com/ubi10-minimal:10.2`

The build workspace uses `/opt/app-root/src` (writable by uid 1001, the go-toolset default user), so no `USER root` is needed. Binaries are installed to `/usr/local/bin/` to align with fulfillment-service.

Fixes: [OSAC-360](https://redhat.atlassian.net/browse/OSAC-360)