### PR TITLE
OSAC-835: add PublicIPAttachment CRD to kustomization

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - bases/osac.openshift.io_subnets.yaml
 - bases/osac.openshift.io_publicippools.yaml
 - bases/osac.openshift.io_publicips.yaml
+- bases/osac.openshift.io_publicipattachments.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:


### PR DESCRIPTION
## Summary

[OSAC-835](https://redhat.atlassian.net/browse/OSAC-835): Add the missing `publicipattachments` entry to `config/crd/kustomization.yaml`.

## Why

The PublicIPAttachment CRD was added in [OSAC-834](https://redhat.atlassian.net/browse/OSAC-834) (PR #245) but the kustomization.yaml
entry was not included. Without it, kustomize-based deployments (including CI E2E) do
not install the CRD on the cluster. The operator then crashes at startup when the
PublicIPAttachment controller (merged in PR #252) tries to set up an informer for the
missing resource type.

This causes `no matches for kind "PublicIPAttachment"` errors and blocks all other
controllers from starting.

## Testing

Verified that the CRD file `config/crd/bases/osac.openshift.io_publicipattachments.yaml`
exists and is correctly referenced.

## Ticket

[OSAC-835](https://redhat.atlassian.net/browse/OSAC-835)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing public IP attachments in OpenShift clusters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->