### PR TITLE
NO_ISSUE: grant hub-access read permissions in per-order namespaces

### DIFF
--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -61,6 +61,7 @@ func (r *ClusterOrderReconciler) components() []component {
 		{"Namespace", r.newNamespace},
 		{"ServiceAccount", r.newServiceAccount},
 		{"RoleBinding", r.newAdminRoleBinding},
+		{"HubAccessRoleBinding", r.newHubAccessRoleBinding},
 	}
 }
 

--- a/internal/controller/clusterorder_names.go
+++ b/internal/controller/clusterorder_names.go
@@ -7,10 +7,14 @@ import (
 )
 
 const (
+	subjectKindServiceAccount    string = "ServiceAccount"
 	defaultServiceAccountName    string = "osac"
 	defaultHostedClusterName     string = "cluster"
 	defaultRoleBindingName       string = "osac"
 	defaultClusterOrderNamespace string = "osac-orders"
+	hubAccessServiceAccountName  string = "hub-access"
+	hubAccessRoleBindingName     string = "hub-access"
+	hubAccessClusterRoleName     string = "hub-access-hosted-clusters"
 )
 
 var (

--- a/internal/controller/clusterorder_resources.go
+++ b/internal/controller/clusterorder_resources.go
@@ -97,7 +97,7 @@ func (r *ClusterOrderReconciler) newAdminRoleBinding(ctx context.Context, instan
 
 	subjects := []rbacv1.Subject{
 		{
-			Kind:      "ServiceAccount",
+			Kind:      subjectKindServiceAccount,
 			Name:      serviceAccountName,
 			Namespace: namespaceName,
 		},
@@ -122,6 +122,43 @@ func (r *ClusterOrderReconciler) newAdminRoleBinding(ctx context.Context, instan
 		ensureCommonLabels(instance, roleBinding)
 		roleBinding.Subjects = subjects
 		roleBinding.RoleRef = roleref
+		return nil
+	}
+
+	return &appResource{
+		roleBinding,
+		mutateFn,
+	}, nil
+}
+
+func (r *ClusterOrderReconciler) newHubAccessRoleBinding(ctx context.Context, instance *v1alpha1.ClusterOrder) (*appResource, error) {
+	namespaceName := instance.GetClusterReferenceNamespace()
+	if namespaceName == "" {
+		return nil, fmt.Errorf("unable to retrieve required information from spec.clusterReference")
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hubAccessRoleBindingName,
+			Namespace: namespaceName,
+			Labels:    commonLabelsFromOrder(instance),
+		},
+	}
+
+	mutateFn := func() error {
+		ensureCommonLabels(instance, roleBinding)
+		roleBinding.Subjects = []rbacv1.Subject{
+			{
+				Kind:      subjectKindServiceAccount,
+				Name:      hubAccessServiceAccountName,
+				Namespace: r.ClusterOrderNamespace,
+			},
+		}
+		roleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     hubAccessClusterRoleName,
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

The fulfillment service authenticates as the `hub-access` service account when retrieving cluster credentials via `GetKubeconfig` / `GetPassword`. These credentials (kubeconfig and kubeadmin password) are stored as Secrets in per-order namespaces (`<osac-ns>-<order-name>`) that are created dynamically by the ClusterOrder controller.

Without RBAC in those namespaces, the fulfillment service gets:
```
hostedclusters.hypershift.openshift.io is forbidden: User "system:serviceaccount:osac-e2e-ci:hub-access"
cannot get resource "hostedclusters" in namespace "osac-e2e-ci-order-xxxxx"
```

This PR adds a `hub-access` RoleBinding in each ClusterOrder namespace, referencing the `hub-access-hosted-clusters` ClusterRole (defined in the installer kustomization). This grants scoped `get` access to `hostedclusters` and `secrets` only in namespaces where OSAC clusters exist — following the same pattern as the existing `osac` admin RoleBinding.

## Changes

- `clusterorder_names.go`: Add constants for hub-access SA name, RoleBinding name, and ClusterRole name
- `clusterorder_resources.go`: Add `newHubAccessRoleBinding` component function
- `clusterorder_controller.go`: Register the new component in `components()`

## Depends on

- osac-installer PR #138 which defines the `hub-access-hosted-clusters` ClusterRole in the kustomization

## Test plan
- [x] `go build ./internal/controller/` compiles
- [x] Existing unit tests pass
- [x] Verified manually: all 7 CaaS e2e tests pass when the ClusterRole + ClusterRoleBinding are applied

🤖 Generated with [Claude Code](https://claude.ai/claude-code)