### PR TITLE
NO-ISSUE: Run go fix after update to go 1.26

### DIFF
--- a/cmd/console-proxy/main_test.go
+++ b/cmd/console-proxy/main_test.go
@@ -40,7 +40,7 @@ var _ = Describe("buildConfigResolver", func() {
 	})
 
 	DescribeTable("with a valid mode returns the correct resolver type",
-		func(mode string, expectedType interface{}) {
+		func(mode string, expectedType any) {
 			resolver, err := buildConfigResolver(mode, fakeClient, hubConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resolver).To(BeAssignableToTypeOf(expectedType))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osac-project/osac-operator
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/coder/websocket v1.8.14

--- a/internal/controller/computeinstance_integration_test.go
+++ b/internal/controller/computeinstance_integration_test.go
@@ -392,7 +392,7 @@ var _ = Describe("ComputeInstance Integration Tests", func() {
 
 			// Set to running and poll multiple times
 			provider.setProvisionJobState(osacv1alpha1.JobStateRunning, "Job running - step 1")
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				result, err := reconciler.handleProvisioning(ctx, instance)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RequeueAfter).To(Equal(100 * time.Millisecond))

--- a/internal/controller/publicip_controller_test.go
+++ b/internal/controller/publicip_controller_test.go
@@ -633,7 +633,7 @@ var _ = Describe("PublicIPReconciler", func() {
 			}
 
 			// Pass 1: finalizer, Pass 2: trigger job, Pass 3: poll -> Succeeded -> OnSuccess
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/internal/controller/publicipattachment_controller_test.go
+++ b/internal/controller/publicipattachment_controller_test.go
@@ -676,7 +676,7 @@ var _ = Describe("PublicIPAttachmentReconciler", func() {
 
 		It("should not map CI changes to unrelated attachments", func() {
 			unrelatedAttachment := attachment.DeepCopy()
-			unrelatedAttachment.Spec.ComputeInstance = ptr.To("other-ci")
+			unrelatedAttachment.Spec.ComputeInstance = new("other-ci")
 			fakeClient = buildClient(unrelatedAttachment, publicIP, pool, ci)
 			setupReconciler(fakeClient)
 

--- a/internal/controller/securitygroup_controller_test.go
+++ b/internal/controller/securitygroup_controller_test.go
@@ -813,7 +813,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			jobs := []osacv1alpha1.JobStatus{}
 
 			// Add 15 jobs
-			for i := 0; i < 15; i++ {
+			for i := range 15 {
 				newJob := osacv1alpha1.JobStatus{
 					JobID:     string(rune('a' + i)),
 					Type:      osacv1alpha1.JobTypeProvision,

--- a/internal/controller/webhook_common_test.go
+++ b/internal/controller/webhook_common_test.go
@@ -71,7 +71,7 @@ func TestWebhookClientCache(t *testing.T) {
 		const workers = 10
 		var wg sync.WaitGroup
 
-		for i := 0; i < workers; i++ {
+		for i := range workers {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
@@ -94,7 +94,7 @@ func TestWebhookClientCache(t *testing.T) {
 		const goroutines = 100
 		var wg sync.WaitGroup
 
-		for i := 0; i < goroutines; i++ {
+		for i := range goroutines {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -150,8 +150,8 @@ func loadImageViaArchive(name, cluster, tool string) error {
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {
 	var res []string
-	elements := strings.Split(output, "\n")
-	for _, element := range elements {
+	elements := strings.SplitSeq(output, "\n")
+	for element := range elements {
 		if element != "" {
 			res = append(res, element)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved multiple unit and integration tests for reliability and consistency.
* **Chores**
  * Updated utility test helpers and bumped the Go toolchain version to a newer release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->