### PR TITLE
OSAC-1121: fix hub-access ClusterRole name to match kustomize prefix

### DIFF
--- a/internal/controller/clusterorder_names.go
+++ b/internal/controller/clusterorder_names.go
@@ -14,7 +14,7 @@ const (
 	defaultClusterOrderNamespace string = "osac-orders"
 	hubAccessServiceAccountName  string = "hub-access"
 	hubAccessRoleBindingName     string = "hub-access"
-	hubAccessClusterRoleName     string = "hub-access-hosted-clusters"
+	hubAccessClusterRoleBaseName string = "hub-access-hosted-clusters"
 )
 
 var (
@@ -26,4 +26,11 @@ var (
 
 func generateNamespaceName(instance *v1alpha1.ClusterOrder) string {
 	return fmt.Sprintf("%s-%s", instance.GetNamespace(), instance.GetName())
+}
+
+// hubAccessClusterRoleName returns the ClusterRole name, accounting for the
+// kustomize prefix transformer that prepends "{namespace}-" to cluster-scoped
+// resources in CI/production overlays.
+func (r *ClusterOrderReconciler) hubAccessClusterRoleName() string {
+	return fmt.Sprintf("%s-%s", r.ClusterOrderNamespace, hubAccessClusterRoleBaseName)
 }

--- a/internal/controller/clusterorder_resources.go
+++ b/internal/controller/clusterorder_resources.go
@@ -157,7 +157,7 @@ func (r *ClusterOrderReconciler) newHubAccessRoleBinding(ctx context.Context, in
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     hubAccessClusterRoleName,
+			Name:     r.hubAccessClusterRoleName(),
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Fix ClusterOrder reconciliation failing with `rolebindings.rbac.authorization.k8s.io "hub-access-hosted-clusters" not found`
- The kustomize prefix transformer prepends `{namespace}-` to ClusterRole names, but the operator hardcoded the unprefixed name
- Replace the constant with a method that constructs the prefixed name from `ClusterOrderNamespace`

Jira: https://redhat.atlassian.net/browse/OSAC-1121

## Test plan

- [ ] CI e2e-caas tests pass (ClusterOrder reaches Ready state)
- [ ] Verify on all overlays: the constructed name matches what kustomize produces (`{namespace}-hub-access-hosted-clusters`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cluster order naming logic for proper management of cluster-scoped resources.
  * Enhanced cluster role binding configurations for better resource resolution across cluster environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-operator/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->