### PR TITLE
OSAC-179: remove deprecated status.storageClass field

### DIFF
--- a/api/v1alpha1/tenant_types.go
+++ b/api/v1alpha1/tenant_types.go
@@ -81,11 +81,6 @@ type TenantStatus struct {
 	// Namespace is the namespace allocated to the tenant on the target cluster
 	Namespace string `json:"namespace,omitempty"`
 
-	// StorageClass is the StorageClass allocated to the tenant on the target cluster.
-	// Deprecated: use StorageClasses instead. Retained for backward compatibility
-	// until all consumers migrate. Will be removed by MGMT-24139.
-	StorageClass string `json:"storageClass,omitempty"`
-
 	// StorageClasses lists all resolved StorageClass mappings for the tenant,
 	// one per storage tier.
 	// +kubebuilder:validation:Optional
@@ -104,7 +99,7 @@ type TenantStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Tenant Namespace",type=string,JSONPath=`.status.namespace`
-// +kubebuilder:printcolumn:name="Storage Class",type=string,JSONPath=`.status.storageClass`
+// +kubebuilder:printcolumn:name="Storage Classes",type=string,JSONPath=`.status.storageClasses[*].name`
 // +kubebuilder:printcolumn:name="Storage Tiers",type=string,JSONPath=`.status.storageClasses[*].tier`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 

--- a/charts/operator-crds/templates/osac.openshift.io_tenants.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_tenants.yaml
@@ -20,8 +20,8 @@ spec:
     - jsonPath: .status.namespace
       name: Tenant Namespace
       type: string
-    - jsonPath: .status.storageClass
-      name: Storage Class
+    - jsonPath: .status.storageClasses[*].name
+      name: Storage Classes
       type: string
     - jsonPath: .status.storageClasses[*].tier
       name: Storage Tiers
@@ -121,12 +121,6 @@ spec:
                 type: string
               phase:
                 description: Phase is the phase of the tenant
-                type: string
-              storageClass:
-                description: |-
-                  StorageClass is the StorageClass allocated to the tenant on the target cluster.
-                  Deprecated: use StorageClasses instead. Retained for backward compatibility
-                  until all consumers migrate. Will be removed by MGMT-24139.
                 type: string
               storageClasses:
                 description: |-

--- a/config/crd/bases/osac.openshift.io_tenants.yaml
+++ b/config/crd/bases/osac.openshift.io_tenants.yaml
@@ -18,8 +18,8 @@ spec:
     - jsonPath: .status.namespace
       name: Tenant Namespace
       type: string
-    - jsonPath: .status.storageClass
-      name: Storage Class
+    - jsonPath: .status.storageClasses[*].name
+      name: Storage Classes
       type: string
     - jsonPath: .status.storageClasses[*].tier
       name: Storage Tiers
@@ -177,12 +177,6 @@ spec:
                 type: string
               phase:
                 description: Phase is the phase of the tenant
-                type: string
-              storageClass:
-                description: |-
-                  StorageClass is the StorageClass allocated to the tenant on the target cluster.
-                  Deprecated: use StorageClasses instead. Retained for backward compatibility
-                  until all consumers migrate. Will be removed by MGMT-24139.
                 type: string
               storageClasses:
                 description: |-

--- a/internal/controller/tenant_controller.go
+++ b/internal/controller/tenant_controller.go
@@ -156,7 +156,6 @@ func (r *TenantReconciler) handleUpdate(ctx context.Context, req reconcile.Reque
 	// Ready. Any early return below leaves the status in a clean Progressing state.
 	instance.Status.Phase = v1alpha1.TenantPhaseProgressing
 	instance.Status.Namespace = ""
-	instance.Status.StorageClass = ""
 	instance.Status.StorageClasses = nil
 
 	// Get target cluster client where namespace, StorageClass, and UDN are reconciled
@@ -218,7 +217,6 @@ func (r *TenantReconciler) handleUpdate(ctx context.Context, req reconcile.Reque
 		result.conditionMessage())
 
 	instance.Status.Namespace = namespace.GetName()
-	instance.Status.StorageClass = result.resolved[0].Name
 	instance.Status.StorageClasses = result.resolved
 
 	// SC found, but if a provision job is still non-terminal, poll it before

--- a/internal/controller/tenant_controller_test.go
+++ b/internal/controller/tenant_controller_test.go
@@ -135,11 +135,9 @@ var _ = Describe("Tenant Controller", func() {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, tenant)).To(Succeed())
 					g.Expect(tenant.Status.Phase).To(Equal(expectedPhase))
 					if expectedSCs == nil {
-						g.Expect(tenant.Status.StorageClass).To(BeEmpty())
 						g.Expect(tenant.Status.StorageClasses).To(BeNil())
 					} else {
 						g.Expect(tenant.Status.StorageClasses).To(ConsistOf(expectedSCs))
-						g.Expect(tenant.Status.StorageClass).To(Equal(expectedSCs[0].Name))
 					}
 
 					nsCond := tenant.GetStatusCondition(v1alpha1.TenantConditionNamespaceReady)


### PR DESCRIPTION
## Summary

Remove the deprecated `status.storageClass` (singular string) field from the Tenant CRD. All consumers have migrated to `status.storageClasses` (plural list with per-tier resolution).

### Why this is not a breaking change

The `status.storageClass` field was a **status subresource** (observed state set by the controller), not a spec field. No external system writes to it. All consumers that previously read it have been migrated:

- **osac-aap** `tenant_storage_class` role: migrated to `storageClasses` list in commit `77c7956` (May 7) — reads from extra_vars injected by the CI controller, no longer queries the Tenant CR directly
- **computeinstance_controller**: only ever used the plural `StorageClasses` field (via the `StorageClassReady` condition)
- **No external API consumers**: the field was never exposed via the fulfillment-service gRPC/REST API — it only existed on the Kubernetes CR

The singular field was kept temporarily to avoid breaking running dev environments on hypershift1 during the multi-tier migration. That migration is complete.

## Changes

- Remove `StorageClass` field from `TenantStatus` struct and its kubebuilder print column
- Replace the "Storage Class" printer column with "Storage Classes" showing `storageClasses[*].name`
- Remove backward-compatibility sync logic in tenant controller (`handleUpdate`)
- Remove corresponding test assertions
- Regenerate CRD manifests (`config/crd/` and `charts/operator-crds/`)

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `make manifests generate` — passes, CRD YAML verified clean
- Existing unit tests updated (removed assertions for deleted field)
- grep verified: no remaining references to singular `status.storageClass` in any OSAC repo

## Jira

https://redhat.atlassian.net/browse/OSAC-179

---
Generated-by: Claude Code (claude-opus-4-6)
Assisted-by: Claude Code <noreply@anthropic.com>