### PR TITLE
OSAC-1079: Bump chart versions from 0.0.0 to 0.1.0

### DIFF
--- a/charts/operator-crds/Chart.yaml
+++ b/charts/operator-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: osac-operator-crds
 description: CRDs for the OSAC Operator
 type: application
-version: 0.0.0
+version: 0.1.0

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: osac-operator
 description: OSAC Operator - manages OSAC custom resources
 type: application
-version: 0.0.0
+version: 0.1.0


### PR DESCRIPTION
## Summary
- Bump `osac-operator` chart version from `0.0.0` to `0.1.0`
- Bump `osac-operator-crds` chart version from `0.0.0` to `0.1.0`

Part of Helm chart production readiness ([OSAC-1072](https://redhat.atlassian.net/browse/OSAC-1072)). Replaces placeholder versions with real semver as the first step toward OCI publication.

## Test plan
- [ ] `helm lint charts/operator`
- [ ] `helm lint charts/operator-crds`
- [ ] `helm template` renders correctly with new versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart versions to 0.1.0 for operator-related charts.
  * Version bump applied across chart metadata to reflect the new package release state and ensure consistent chart versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->