### PR TITLE
fix: Align Makefile GOTOOLCHAIN with go.mod (go 1.26.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ CONTAINERFILE ?= Containerfile
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
+# Go version for local make targets. Keep in sync with go.mod.
+GO_VERSION ?= 1.26.2
+GOTOOLCHAIN ?= go$(GO_VERSION)
+GOTOOLCHAIN_AUTO ?= $(GOTOOLCHAIN)+auto
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -120,7 +125,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	GOTOOLCHAIN=go1.25.0+auto KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	GOTOOLCHAIN=$(GOTOOLCHAIN_AUTO) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 .PHONY: test-integration
 test-integration: test test-kustomize test-smoke ## Run all tests including integration (kustomize + smoke).
@@ -337,7 +342,7 @@ set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOTOOLCHAIN=go1.25.0 GOBIN=$(LOCALBIN) go install $${package} ;\
+GOTOOLCHAIN=$(GOTOOLCHAIN) GOBIN=$(LOCALBIN) go install $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)


### PR DESCRIPTION
fix related to https://github.com/osac-project/osac-operator/pull/264

- Centralize Go toolchain version in Makefile (`GO_VERSION`, `GOTOOLCHAIN`, `GOTOOLCHAIN_AUTO`) and set to 1.26.2 to match `go.mod`
- Affects the `test` target and the `go-install-tool` helper used to install controller-gen, envtest, and other build tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build system to use a newer Go toolchain version for development and testing. This improvement enhances overall stability, compatibility, and build performance across workflows. The change ensures the project maintains alignment with the latest Go releases and benefits from recent toolchain enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->