### PR TITLE
fix: Repair helm-crds sync and add CI drift check

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -10,6 +10,9 @@ on:
       - 'Makefile'
       - '.github/workflows/helm-lint.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   helm-crds-sync:
     name: Check Helm CRD sync
@@ -17,6 +20,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -32,6 +37,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Helm
       uses: azure/setup-helm@v5

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -3,11 +3,29 @@ name: Helm Lint
 on:
   pull_request:
     paths:
+      - 'api/**'
       - 'charts/**'
       - 'config/crd/bases/**'
+      - 'hack/sync-helm-crds.py'
+      - 'Makefile'
       - '.github/workflows/helm-lint.yaml'
 
 jobs:
+  helm-crds-sync:
+    name: Check Helm CRD sync
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: stable
+
+    - name: Verify Helm CRD templates match bases
+      run: make check-helm-crds
+
   helm-lint:
     name: Lint Helm charts
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ OSAC operator is a Kubernetes operator that reconciles infrastructure resources 
 ## Critical Rules
 
 - **Always `make manifests generate`** after modifying CRD types in `api/v1alpha1/*_types.go`
+- **Always `make helm-crds`** after regenerating CRDs (or run `make check-helm-crds` to verify sync)
 - **Never edit** `config/crd/`, `zz_generated.deepcopy.go`, or `internal/api/` — all generated
 - **Always `buf generate`** after updating the module version in `buf.gen.yaml`
 - **Commit message format**: `MGMT-XXXXX: description of change`

--- a/Makefile
+++ b/Makefile
@@ -168,19 +168,20 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 .PHONY: helm-crds
 helm-crds: manifests ## Copy generated CRDs into the operator-crds Helm chart.
 	@echo "Syncing CRDs to charts/operator-crds/templates/..."
-	@for f in config/crd/bases/*.yaml; do \
-		name=$$(basename "$$f"); \
-		python3 -c " \
-import sys, re; \
-content = open(sys.argv[1]).read(); \
-if 'helm.sh/resource-policy' not in content: \
-    content = content.replace('  annotations:\n', '  annotations:\n    \"helm.sh/resource-policy\": keep\n'); \
-content = '{{- if .Values.install }}\n' + content + '{{- end }}\n'; \
-open(sys.argv[2], 'w').write(content)" \
-			"$$f" "charts/operator-crds/templates/$$name"; \
-		echo "  $$name"; \
-	done
-	@echo "Done."
+	@python3 hack/sync-helm-crds.py
+
+.PHONY: check-helm-crds
+check-helm-crds: helm-crds ## Verify Helm CRD templates match config/crd/bases.
+	@if ! git diff --quiet -- charts/operator-crds/templates/; then \
+		echo "Helm CRD templates are out of sync with config/crd/bases. Run 'make helm-crds' and commit."; \
+		git diff -- charts/operator-crds/templates/; \
+		exit 1; \
+	fi
+	@if [ -n "$$(git ls-files --others --exclude-standard -- charts/operator-crds/templates/)" ]; then \
+		echo "Missing Helm CRD templates (run 'make helm-crds' and commit):"; \
+		git ls-files --others --exclude-standard -- charts/operator-crds/templates/; \
+		exit 1; \
+	fi
 
 ##@ API Module
 

--- a/charts/operator-crds/templates/osac.openshift.io_clusterorders.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_clusterorders.yaml
@@ -1,8 +1,10 @@
+{{- if .Values.install }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.20.0
   name: clusterorders.osac.openshift.io
 spec:
@@ -258,8 +260,6 @@ spec:
                       enum:
                       - provision
                       - deprovision
-                      - attach
-                      - detach
                       type: string
                   required:
                   - jobID
@@ -301,3 +301,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
@@ -37,6 +37,10 @@ spec:
     - jsonPath: .status.ipAddress
       name: IP
       type: string
+    - jsonPath: .status.publicIPAddress
+      name: PublicIP
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -132,6 +136,58 @@ spec:
                 x-kubernetes-validations:
                 - message: memoryGiB is immutable
                   rule: self == oldSelf
+              networkAttachments:
+                description: |-
+                  NetworkAttachments defines multiple NICs when more than one subnet (and optional security groups per NIC) is required.
+                  When non-empty, subnetRef must be empty; the first entry is the primary subnet for VM placement (subnet-namespace annotation).
+                  Subnet references (per NetworkAttachment) are immutable but security groups can be changed.
+
+                  Why immutability is required:
+                  Currently, ComputeInstances are created with a single NIC. The VM instance must be created in the namespace
+                  of the subnet it uses (the subnet-namespace annotation determines VM placement). This architectural constraint
+                  means that changing the subnet would require recreating the VM in a different namespace, which is not supported.
+                  Similarly, the array size cannot change because adding/removing NICs would require changing the primary subnet
+                  or the VM's namespace, both of which are immutable after VM creation.
+
+                  Immutability enforcement:
+                  - The +listType=map with +listMapKey=subnetRef markers correlate entries by subnetRef for updates
+                  - The size check below prevents adding or removing entries
+                  - The per-item subnetRef validation (self == oldSelf) prevents changing keys of existing entries
+                  Combined, these ensure only securityGroupRefs can be modified.
+
+                  MaxItems is required for CEL cost budget calculation: NetworkAttachment.SubnetRef has a CEL validation
+                  rule (self == oldSelf for immutability). Without maxItems, Kubernetes cannot bound the cost of iterating
+                  over array items to validate this rule, causing CRD installation to fail with "estimated rule cost exceeds budget".
+                items:
+                  description: 'NetworkAttachment defines one NIC: a Subnet CR on
+                    the hub plus optional SecurityGroup CR names.'
+                  properties:
+                    securityGroupRefs:
+                      description: |-
+                        SecurityGroupRefs lists SecurityGroup CR names in the same namespace as the ComputeInstance.
+                        Mutable - can be changed to add/remove security groups without recreating the VM.
+                      items:
+                        type: string
+                      type: array
+                    subnetRef:
+                      description: SubnetRef is the name of the Subnet CR in the same
+                        namespace as the ComputeInstance.
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: subnetRef is immutable
+                        rule: self == oldSelf
+                  required:
+                  - subnetRef
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - subnetRef
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: cannot add or remove network attachments
+                  rule: size(self) == size(oldSelf)
               restartRequestedAt:
                 description: |-
                   RestartRequestedAt is a timestamp signal to request a VM restart (MUTABLE).
@@ -202,6 +258,10 @@ spec:
             - runStrategy
             - templateID
             type: object
+            x-kubernetes-validations:
+            - message: subnetRef must be empty when networkAttachments is set
+              rule: '!(has(self.networkAttachments) && size(self.networkAttachments)
+                > 0 && has(self.subnetRef) && self.subnetRef != "")'
           status:
             description: status defines the observed state of ComputeInstance
             properties:
@@ -351,6 +411,11 @@ spec:
                 - Stopping
                 - Stopped
                 - Paused
+                type: string
+              publicIPAddress:
+                description: |-
+                  PublicIPAddress is the public IP address attached to this instance via a PublicIP CR.
+                  Populated when a PublicIP CR in state "Attached" references this ComputeInstance.
                 type: string
               tenantReference:
                 description: Reference to the tenant that contains the ComputeInstance

--- a/charts/operator-crds/templates/osac.openshift.io_publicipattachments.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_publicipattachments.yaml
@@ -6,33 +6,36 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: tenants.osac.openshift.io
+  name: publicipattachments.osac.openshift.io
 spec:
   group: osac.openshift.io
   names:
-    kind: Tenant
-    listKind: TenantList
-    plural: tenants
-    singular: tenant
+    kind: PublicIPAttachment
+    listKind: PublicIPAttachmentList
+    plural: publicipattachments
+    shortNames:
+    - publicipattachment
+    singular: publicipattachment
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.namespace
-      name: Tenant Namespace
+    - jsonPath: .spec.publicIP
+      name: PublicIP
       type: string
-    - jsonPath: .status.storageClass
-      name: Storage Class
-      type: string
-    - jsonPath: .status.storageClasses[*].tier
-      name: Storage Tiers
+    - jsonPath: .spec.computeInstance
+      name: ComputeInstance
       type: string
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Tenant is the Schema for the tenants API.
+        description: PublicIPAttachment is the Schema for the publicipattachments
+          API
         properties:
           apiVersion:
             description: |-
@@ -52,14 +55,30 @@ spec:
           metadata:
             type: object
           spec:
-            description: TenantSpec defines the desired state of Tenant.
+            description: spec defines the desired state of PublicIPAttachment
+            properties:
+              computeInstance:
+                description: |-
+                  ComputeInstance is the name of the ComputeInstance to attach to.
+                  Exactly one target field must be set.
+                minLength: 1
+                type: string
+              publicIP:
+                description: PublicIP is the name of the PublicIP resource to attach.
+                minLength: 1
+                type: string
+            required:
+            - publicIP
             type: object
+            x-kubernetes-validations:
+            - message: spec is immutable after creation
+              rule: self == oldSelf
           status:
-            description: TenantStatus defines the observed state of Tenant.
+            description: status defines the observed state of PublicIPAttachment
             properties:
               conditions:
                 description: Conditions holds an array of metav1.Condition that describe
-                  the state of the Tenant
+                  the state of the PublicIPAttachment
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -115,9 +134,13 @@ spec:
                   - type
                   type: object
                 type: array
+              desiredConfigVersion:
+                description: DesiredConfigVersion is a hash of the spec, used to detect
+                  spec changes and control retry behavior.
+                type: string
               jobs:
-                description: Jobs holds the history of provisioning jobs triggered
-                  for this tenant
+                description: Jobs holds an array of JobStatus tracking provisioning
+                  and deprovisioning operations
                 items:
                   description: JobStatus represents the status of a provisioning or
                     deprovisioning job
@@ -173,49 +196,18 @@ spec:
                   - type
                   type: object
                 type: array
-              namespace:
-                description: Namespace is the namespace allocated to the tenant on
-                  the target cluster
-                type: string
               phase:
-                description: Phase is the phase of the tenant
+                description: Phase provides a single-value overview of the state of
+                  the PublicIPAttachment
+                enum:
+                - Progressing
+                - Failed
+                - Ready
+                - Deleting
                 type: string
-              storageClass:
-                description: |-
-                  StorageClass is the StorageClass allocated to the tenant on the target cluster.
-                  Deprecated: use StorageClasses instead. Retained for backward compatibility
-                  until all consumers migrate. Will be removed by MGMT-24139.
-                type: string
-              storageClasses:
-                description: |-
-                  StorageClasses lists all resolved StorageClass mappings for the tenant,
-                  one per storage tier.
-                items:
-                  description: |-
-                    ResolvedStorageClass captures a single resolved StorageClass for a specific
-                    storage tier. The Tenant controller populates one entry per tier.
-                  properties:
-                    name:
-                      description: Name is the name of the resolved Kubernetes StorageClass.
-                      minLength: 1
-                      type: string
-                    tier:
-                      description: |-
-                        Tier is the storage tier this StorageClass provides,
-                        taken from the osac.openshift.io/storage-tier label.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$
-                      type: string
-                  required:
-                  - name
-                  - tier
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - tier
-                x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/charts/operator-crds/templates/osac.openshift.io_publicippools.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_publicippools.yaml
@@ -72,6 +72,7 @@ spec:
                   Defaults to metallb-l2 for v7.0.
                 enum:
                 - metallb-l2
+                - netris
                 type: string
               ipFamily:
                 description: IPFamily indicates the IP address family for this pool

--- a/charts/operator-crds/templates/osac.openshift.io_publicips.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_publicips.yaml
@@ -59,12 +59,6 @@ spec:
           spec:
             description: spec defines the desired state of PublicIP
             properties:
-              computeInstance:
-                description: |-
-                  ComputeInstance is the optional name of the ComputeInstance this IP is attached to.
-                  Setting this field triggers attachment of the IP to the referenced instance.
-                minLength: 1
-                type: string
               pool:
                 description: |-
                   Pool is the name of the PublicIPPool this IP is allocated from.
@@ -83,6 +77,10 @@ spec:
               address:
                 description: Address is the allocated public IP address
                 type: string
+              attached:
+                description: Attached indicates whether a PublicIPAttachment has successfully
+                  attached this IP to a target.
+                type: boolean
               conditions:
                 description: Conditions holds an array of metav1.Condition that describe
                   the state of the PublicIP
@@ -217,9 +215,6 @@ spec:
                 enum:
                 - Pending
                 - Allocated
-                - Attaching
-                - Attached
-                - Releasing
                 - Failed
                 type: string
             type: object

--- a/hack/sync-helm-crds.py
+++ b/hack/sync-helm-crds.py
@@ -10,12 +10,39 @@ BASES_DIR = Path("config/crd/bases")
 TEMPLATES_DIR = Path("charts/operator-crds/templates")
 
 
-def wrap_for_helm(content: str) -> str:
-    if "helm.sh/resource-policy" not in content:
-        content = content.replace(
-            "  annotations:\n",
-            '  annotations:\n    "helm.sh/resource-policy": keep\n',
+def inject_resource_policy_annotation(content: str) -> str:
+    if "helm.sh/resource-policy" in content:
+        return content
+
+    annotations_anchor = "  annotations:\n"
+    if annotations_anchor in content:
+        updated = content.replace(
+            annotations_anchor,
+            annotations_anchor + '    "helm.sh/resource-policy": keep\n',
+            1,
         )
+        if updated != content:
+            return updated
+
+    metadata_anchor = "metadata:\n"
+    if metadata_anchor in content:
+        updated = content.replace(
+            metadata_anchor,
+            metadata_anchor
+            + "  annotations:\n"
+            + '    "helm.sh/resource-policy": keep\n',
+            1,
+        )
+        if updated != content:
+            return updated
+
+    raise SystemExit(
+        "Could not inject helm.sh/resource-policy: keep (metadata section not found)"
+    )
+
+
+def wrap_for_helm(content: str) -> str:
+    content = inject_resource_policy_annotation(content)
     return "{{- if .Values.install }}\n" + content + "{{- end }}\n"
 
 

--- a/hack/sync-helm-crds.py
+++ b/hack/sync-helm-crds.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Sync config/crd/bases CRDs into charts/operator-crds/templates for Helm."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BASES_DIR = Path("config/crd/bases")
+TEMPLATES_DIR = Path("charts/operator-crds/templates")
+
+
+def wrap_for_helm(content: str) -> str:
+    if "helm.sh/resource-policy" not in content:
+        content = content.replace(
+            "  annotations:\n",
+            '  annotations:\n    "helm.sh/resource-policy": keep\n',
+        )
+    return "{{- if .Values.install }}\n" + content + "{{- end }}\n"
+
+
+def sync_crds() -> None:
+    if not BASES_DIR.is_dir():
+        raise SystemExit(f"CRD bases directory not found: {BASES_DIR}")
+
+    TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+
+    base_files = sorted(BASES_DIR.glob("*.yaml"))
+    if not base_files:
+        raise SystemExit(f"No CRD YAML files found in {BASES_DIR}")
+
+    expected_names = {path.name for path in base_files}
+
+    for src in base_files:
+        dst = TEMPLATES_DIR / src.name
+        dst.write_text(wrap_for_helm(src.read_text()))
+        print(f"  {src.name}")
+
+    for stale in sorted(TEMPLATES_DIR.glob("osac.openshift.io_*.yaml")):
+        if stale.name not in expected_names:
+            stale.unlink()
+            print(f"  removed stale template {stale.name}")
+
+
+def main() -> int:
+    print(f"Syncing CRDs from {BASES_DIR} to {TEMPLATES_DIR}...")
+    sync_crds()
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes the broken `make helm-crds` target and adds CI to catch drift between `config/crd/bases/` and `charts/operator-crds/templates/`.

## Problem

- `make helm-crds` used a Python one-liner that fails with `SyntaxError` on Python 3 — devs couldn't sync Helm CRD templates locally
- No CI compared Helm CRD templates to generated bases
- `main` had accumulated drift (missing `publicipattachments` template, stale schema in others)

## Changes

- Add `hack/sync-helm-crds.py` — reliable sync from bases to Helm templates (also removes stale templates)
- Fix `make helm-crds` to call the script
- Add `make check-helm-crds` — re-sync and fail if templates differ or are missing
- Add `helm-crds-sync` job to `helm-lint.yaml` (triggers on `api/**`, CRD bases, charts, Makefile)
- Sync `charts/operator-crds/templates/` to match current `config/crd/bases/`
- Document `make helm-crds` in `AGENTS.md`

## Test plan

- [x] `make helm-crds` — pass
- [x] `make check-helm-crds` — pass (no diff after sync)
- [x] `helm lint charts/operator-crds/` — pass
- [x] `helm template test charts/operator-crds/` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PublicIPAttachment CRD for managing IP attachments
  * Multi‑NIC networkAttachments added to ComputeInstance (with validations)
  * PublicIP shown as a printer column on ComputeInstance
  * PublicIPPool accepts a new implementation strategy option
  * Tenant status now records provisioning/deprovisioning jobs

* **Bug Fixes**
  * Improved PublicIP attachment/status and job state tracking
  * Renamed ClusterOrder job types to clearer values

* **Documentation**
  * Clarified CRD regeneration/checking guidance

* **Chores**
  * CI now verifies CRD/Helm template synchronization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->