### PR TITLE
OSAC-1156: Add ImplementationStrategy field to SecurityGroup spec

### DIFF
--- a/api/v1alpha1/securitygroup_types.go
+++ b/api/v1alpha1/securitygroup_types.go
@@ -76,6 +76,12 @@ type SecurityGroupSpec struct {
 	// +kubebuilder:validation:Type=string
 	VirtualNetwork string `json:"virtualNetwork"`
 
+	// ImplementationStrategy determines the backend used to enforce security rules.
+	// Set by the fulfillment-service; defaults to network_policy when empty.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Type=string
+	ImplementationStrategy string `json:"implementationStrategy,omitempty"`
+
 	// IngressRules defines the ingress security rules
 	// +kubebuilder:validation:Optional
 	IngressRules []SecurityRule `json:"ingressRules,omitempty"`

--- a/charts/operator-crds/templates/osac.openshift.io_securitygroups.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_securitygroups.yaml
@@ -97,6 +97,11 @@ spec:
                   - protocol
                   type: object
                 type: array
+              implementationStrategy:
+                description: |-
+                  ImplementationStrategy determines the backend used to enforce security rules.
+                  Set by the fulfillment-service; defaults to network_policy when empty.
+                type: string
               ingressRules:
                 description: IngressRules defines the ingress security rules
                 items:

--- a/config/crd/bases/osac.openshift.io_securitygroups.yaml
+++ b/config/crd/bases/osac.openshift.io_securitygroups.yaml
@@ -95,6 +95,11 @@ spec:
                   - protocol
                   type: object
                 type: array
+              implementationStrategy:
+                description: |-
+                  ImplementationStrategy determines the backend used to enforce security rules.
+                  Set by the fulfillment-service; defaults to network_policy when empty.
+                type: string
               ingressRules:
                 description: IngressRules defines the ingress security rules
                 items:

--- a/internal/controller/constants_common.go
+++ b/internal/controller/constants_common.go
@@ -42,6 +42,11 @@ const (
 	// Used by PublicIPPool (from its own spec) and PublicIP (inherited from parent pool).
 	defaultPublicIPPoolImplementationStrategy = "metallb-l2"
 
+	// defaultSecurityGroupImplementationStrategy is the implementation strategy for SecurityGroup.
+	// SecurityGroup enforcement uses standard Kubernetes NetworkPolicy, independent of the
+	// VirtualNetwork's NetworkClass.
+	defaultSecurityGroupImplementationStrategy = "network_policy"
+
 	deprovisioningJobTriggeredMessage = "Deprovisioning job triggered"
 
 	conditionReasonConfigurationApplied  = "ConfigurationApplied"

--- a/internal/controller/securitygroup_controller.go
+++ b/internal/controller/securitygroup_controller.go
@@ -149,26 +149,10 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 		sg.Status.Phase = v1alpha1.SecurityGroupPhaseProgressing
 	}
 
-	// Lookup parent VirtualNetwork by UUID label to get implementation strategy
-	vnetList := &v1alpha1.VirtualNetworkList{}
-	err := r.List(ctx, vnetList,
-		client.InNamespace(sg.Namespace),
-		client.MatchingLabels{osacVirtualNetworkIDLabel: sg.Spec.VirtualNetwork},
-	)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to list VirtualNetworks: %w", err)
-	}
-	if len(vnetList.Items) == 0 {
-		log.Info("parent VirtualNetwork not found, requeueing", "uuid", sg.Spec.VirtualNetwork)
-		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
-	}
-	vnet := &vnetList.Items[0]
-
-	// Read implementation strategy from parent VirtualNetwork spec
-	implementationStrategy := vnet.Spec.ImplementationStrategy
+	// Read implementation strategy from spec (set by fulfillment-service), fall back to default
+	implementationStrategy := sg.Spec.ImplementationStrategy
 	if implementationStrategy == "" {
-		log.Info("implementation strategy not set on parent VirtualNetwork, requeueing", "virtualNetwork", vnet.Name)
-		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		implementationStrategy = defaultSecurityGroupImplementationStrategy
 	}
 
 	// Add implementation-strategy annotation if not present or different

--- a/internal/controller/securitygroup_controller_test.go
+++ b/internal/controller/securitygroup_controller_test.go
@@ -226,58 +226,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(provisionCalled).To(BeTrue())
 		})
 
-		It("should requeue if parent VirtualNetwork not found", func() {
-			// Create SecurityGroup with non-existent parent
-			orphanSg := &osacv1alpha1.SecurityGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "orphan-sg",
-					Namespace: "test-namespace",
-				},
-				Spec: osacv1alpha1.SecurityGroupSpec{
-					VirtualNetwork: "non-existent-vnet",
-				},
-			}
-			Expect(fakeClient.Create(ctx, orphanSg)).To(Succeed())
-
-			key := types.NamespacedName{Name: orphanSg.Name, Namespace: orphanSg.Namespace}
-
-			// First reconcile adds finalizer
-			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-
-			// Second reconcile should requeue
-			result, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
-		})
-
-		It("should read implementation strategy from parent VirtualNetwork", func() {
-			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
-
-			// Setup mock to capture the call
-			provisionTriggered := false
-			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
-				// At this point, the controller has successfully read ImplementationStrategy
-				// from parent VirtualNetwork and triggered provisioning
-				provisionTriggered = true
-				return &provisioning.ProvisionResult{
-					JobID:        "job-123",
-					InitialState: osacv1alpha1.JobStatePending,
-					Message:      "Job triggered",
-				}, nil
-			}
-
-			// Reconcile twice (first adds finalizer, second provisions)
-			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-
-			// Verify provisioning was triggered (indicating ImplementationStrategy was read)
-			Expect(provisionTriggered).To(BeTrue())
-		})
-
-		It("should set implementation-strategy annotation from parent VirtualNetwork", func() {
+		It("should default to network_policy strategy when spec has no implementationStrategy", func() {
 			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
 
 			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
@@ -298,19 +247,57 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
-			// Verify annotation was set to match parent VirtualNetwork's ImplementationStrategy
+			// Verify annotation was set to the default network_policy strategy
 			Expect(updated.Annotations).NotTo(BeNil())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("cudn-net"))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
+		})
+
+		It("should use implementationStrategy from spec when set", func() {
+			sgWithStrategy := &osacv1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sg-with-strategy",
+					Namespace: "test-namespace",
+				},
+				Spec: osacv1alpha1.SecurityGroupSpec{
+					VirtualNetwork:         "test-vnet-uuid",
+					ImplementationStrategy: "custom-backend",
+				},
+			}
+			Expect(fakeClient.Create(ctx, sgWithStrategy)).To(Succeed())
+
+			key := types.NamespacedName{Name: sgWithStrategy.Name, Namespace: sgWithStrategy.Namespace}
+
+			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
+				return &provisioning.ProvisionResult{
+					JobID:        "job-custom",
+					InitialState: osacv1alpha1.JobStatePending,
+					Message:      "Job triggered",
+				}, nil
+			}
+
+			// Reconcile twice (first adds finalizer, second sets annotation and provisions)
+			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Fetch updated SecurityGroup
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
+
+			// Verify annotation was set to the spec-provided strategy
+			Expect(updated.Annotations).NotTo(BeNil())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("custom-backend"))
 		})
 
 		It("should not update when annotation already matches implementation strategy", func() {
-			// Create SecurityGroup with annotation already set
+			// Create SecurityGroup with annotation already set to the default
 			sgWithAnnotation := &osacv1alpha1.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sg-with-annotation",
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						osacImplementationStrategyAnnotation: "cudn-net",
+						osacImplementationStrategyAnnotation: defaultSecurityGroupImplementationStrategy,
 					},
 				},
 				Spec: osacv1alpha1.SecurityGroupSpec{
@@ -340,11 +327,11 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
 			// Verify annotation still matches (no duplicate Update calls)
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("cudn-net"))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
 		})
 
-		It("should update annotation when it differs from parent VirtualNetwork", func() {
-			// Create SecurityGroup with different annotation value
+		It("should update annotation when it differs from the resolved strategy", func() {
+			// Create SecurityGroup with a stale annotation value
 			sgDifferentAnnotation := &osacv1alpha1.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sg-different-annotation",
@@ -379,49 +366,8 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
-			// Verify annotation was updated to match parent VirtualNetwork
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("cudn-net"))
-		})
-
-		It("should requeue if parent VirtualNetwork has no ImplementationStrategy", func() {
-			// Create VirtualNetwork without ImplementationStrategy
-			vnetNoStrategy := &osacv1alpha1.VirtualNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vnet-no-strategy",
-					Namespace: "test-namespace",
-					Labels: map[string]string{
-						osacVirtualNetworkIDLabel: "vnet-no-strategy-uuid",
-					},
-				},
-				Spec: osacv1alpha1.VirtualNetworkSpec{
-					Region:       "us-west-1",
-					NetworkClass: "some-class",
-					// ImplementationStrategy intentionally not set
-				},
-			}
-			Expect(fakeClient.Create(ctx, vnetNoStrategy)).To(Succeed())
-
-			sgNoStrategy := &osacv1alpha1.SecurityGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sg-no-strategy",
-					Namespace: "test-namespace",
-				},
-				Spec: osacv1alpha1.SecurityGroupSpec{
-					VirtualNetwork: "vnet-no-strategy-uuid",
-				},
-			}
-			Expect(fakeClient.Create(ctx, sgNoStrategy)).To(Succeed())
-
-			key := types.NamespacedName{Name: sgNoStrategy.Name, Namespace: sgNoStrategy.Namespace}
-
-			// First reconcile adds finalizer
-			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-
-			// Second reconcile should requeue due to missing ImplementationStrategy
-			result, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+			// Verify annotation was updated to the default strategy
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
 		})
 
 		It("should trigger provision job when no job exists", func() {


### PR DESCRIPTION
SecurityGroup now reads its implementation strategy from
spec.implementationStrategy (set by the fulfillment-service),
falling back to "network_policy" when unset. This follows the
PublicIPPool pattern and keeps the policy decision in the
fulfillment-service rather than hardcoding it in the operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SecurityGroups now support a configurable `implementationStrategy` field to specify how security policies are enforced. When not explicitly set, `network_policy` is used as the default enforcement mechanism.

* **Refactor**
  * SecurityGroup strategy configuration is now resolved directly from the SecurityGroup specification instead of being read from parent VirtualNetwork configurations, reducing configuration dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->