### PR TITLE
ci: Run make test-smoke in build-image workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: Validate kustomize configurations
         run: make test-kustomize
 
+      - name: Run smoke test
+        run: make test-smoke
+
   build:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -22,6 +22,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -43,6 +45,7 @@ jobs:
         run: make test-kustomize
 
       - name: Run smoke test
+        timeout-minutes: 15
         run: make test-smoke
 
   build:


### PR DESCRIPTION
## Summary

- Run `make test-smoke` in the `build-image.yaml` test job, giving the existing kind install step a purpose
- Smoke test creates an ephemeral `osac-test` kind cluster, applies CRDs, creates the sample `ComputeInstance`, verifies `kubectl get`, then tears down

## Context

CI has installed kind since #95 but only ran `make test` (envtest) and `make test-kustomize`. `test-smoke` was Makefile-only via `make test-integration`.

`test-e2e` is intentionally out of scope here — it installs cert-manager and Prometheus, builds/pushes the operator image into kind, deploys `config/testing/default`, and runs reconciliation tests (~minutes, heavier deps).

## Test plan

- [x] `make test-smoke` passes locally
- [x] GitHub Actions `Build container image` workflow passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a smoke test to the CI pipeline to improve release quality assurance.
* **Chores**
  * Updated CI workflow permissions to ensure tests run reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->