### PR TITLE
OSAC-769: Remove legacy SubnetRef field from ComputeInstance CRD

### DIFF
--- a/api/v1alpha1/computeinstance_types.go
+++ b/api/v1alpha1/computeinstance_types.go
@@ -71,6 +71,7 @@ type NetworkAttachment struct {
 	// SubnetRef is the name of the Subnet CR in the same namespace as the ComputeInstance.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subnetRef is immutable"
 	SubnetRef string `json:"subnetRef"`
 
@@ -81,8 +82,6 @@ type NetworkAttachment struct {
 }
 
 // ComputeInstanceSpec defines the desired state of ComputeInstance
-//
-// +kubebuilder:validation:XValidation:rule="!(has(self.networkAttachments) && size(self.networkAttachments) > 0 && has(self.subnetRef) && self.subnetRef != \"\")",message="subnetRef must be empty when networkAttachments is set"
 type ComputeInstanceSpec struct {
 	// TemplateID is the unique identifier of the compute instance template to use when creating this compute instance
 	// +kubebuilder:validation:Required
@@ -138,13 +137,8 @@ type ComputeInstanceSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="sshKey is immutable"
 	SSHKey string `json:"sshKey,omitempty"`
 
-	// SubnetRef is the name of the Subnet CR in the hub cluster
-	// This references the Kubernetes CR name (not the fulfillment ID)
-	// +kubebuilder:validation:Optional
-	SubnetRef string `json:"subnetRef,omitempty"`
-
 	// NetworkAttachments defines multiple NICs when more than one subnet (and optional security groups per NIC) is required.
-	// When non-empty, subnetRef must be empty; the first entry is the primary subnet for VM placement (subnet-namespace annotation).
+	// The first entry is the primary subnet for VM placement (subnet-namespace annotation).
 	// Subnet references (per NetworkAttachment) are immutable but security groups can be changed.
 	//
 	// Why immutability is required:
@@ -165,7 +159,7 @@ type ComputeInstanceSpec struct {
 	// over array items to validate this rule, causing CRD installation to fail with "estimated rule cost exceeds budget".
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:validation:XValidation:rule="size(self) == size(oldSelf)",message="cannot add or remove network attachments"
+	// +kubebuilder:validation:XValidation:rule="size(oldSelf) == 0 || (size(self) == size(oldSelf) && self.all(na, oldSelf.exists(old, old.subnetRef == na.subnetRef)))",message="cannot change or add/remove network attachments after initial assignment"
 	// +listType=map
 	// +listMapKey=subnetRef
 	NetworkAttachments []NetworkAttachment `json:"networkAttachments,omitempty"`
@@ -353,10 +347,10 @@ func (ci *ComputeInstance) GetName() string {
 }
 
 // PrimarySubnetRef returns the Subnet CR name used for VM placement and the subnet-namespace annotation:
-// the first networkAttachments[].subnetRef when that list is non-empty, otherwise spec.subnetRef (legacy single-NIC).
+// the first networkAttachments[].subnetRef when that list is non-empty, otherwise empty string.
 func (s ComputeInstanceSpec) PrimarySubnetRef() string {
 	if len(s.NetworkAttachments) > 0 {
 		return s.NetworkAttachments[0].SubnetRef
 	}
-	return s.SubnetRef
+	return ""
 }

--- a/api/v1alpha1/computeinstance_types_test.go
+++ b/api/v1alpha1/computeinstance_types_test.go
@@ -166,15 +166,7 @@ var _ = Describe("ComputeInstance", func() {
 			Expect(spec.PrimarySubnetRef()).To(Equal("subnet-A"))
 		})
 
-		It("should return legacy subnetRef when networkAttachments is empty", func() {
-			spec := v1alpha1.ComputeInstanceSpec{
-				SubnetRef: "legacy-subnet",
-			}
-
-			Expect(spec.PrimarySubnetRef()).To(Equal("legacy-subnet"))
-		})
-
-		It("should return empty string when both are unset", func() {
+		It("should return empty string when networkAttachments is empty", func() {
 			spec := v1alpha1.ComputeInstanceSpec{}
 
 			Expect(spec.PrimarySubnetRef()).To(Equal(""))

--- a/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
@@ -139,7 +139,7 @@ spec:
               networkAttachments:
                 description: |-
                   NetworkAttachments defines multiple NICs when more than one subnet (and optional security groups per NIC) is required.
-                  When non-empty, subnetRef must be empty; the first entry is the primary subnet for VM placement (subnet-namespace annotation).
+                  The first entry is the primary subnet for VM placement (subnet-namespace annotation).
                   Subnet references (per NetworkAttachment) are immutable but security groups can be changed.
 
                   Why immutability is required:
@@ -172,6 +172,7 @@ spec:
                     subnetRef:
                       description: SubnetRef is the name of the Subnet CR in the same
                         namespace as the ComputeInstance.
+                      maxLength: 253
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
@@ -186,8 +187,10 @@ spec:
                 - subnetRef
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: cannot add or remove network attachments
-                  rule: size(self) == size(oldSelf)
+                - message: cannot change or add/remove network attachments after initial
+                    assignment
+                  rule: size(oldSelf) == 0 || (size(self) == size(oldSelf) && self.all(na,
+                    oldSelf.exists(old, old.subnetRef == na.subnetRef)))
               restartRequestedAt:
                 description: |-
                   RestartRequestedAt is a timestamp signal to request a VM restart (MUTABLE).
@@ -216,11 +219,6 @@ spec:
                 x-kubernetes-validations:
                 - message: sshKey is immutable
                   rule: self == oldSelf
-              subnetRef:
-                description: |-
-                  SubnetRef is the name of the Subnet CR in the hub cluster
-                  This references the Kubernetes CR name (not the fulfillment ID)
-                type: string
               templateID:
                 description: TemplateID is the unique identifier of the compute instance
                   template to use when creating this compute instance
@@ -258,10 +256,6 @@ spec:
             - runStrategy
             - templateID
             type: object
-            x-kubernetes-validations:
-            - message: subnetRef must be empty when networkAttachments is set
-              rule: '!(has(self.networkAttachments) && size(self.networkAttachments)
-                > 0 && has(self.subnetRef) && self.subnetRef != "")'
           status:
             description: status defines the observed state of ComputeInstance
             properties:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	cluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -60,6 +61,7 @@ import (
 	v1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 	"github.com/osac-project/osac-operator/helpers"
 	"github.com/osac-project/osac-operator/internal/controller"
+	"github.com/osac-project/osac-operator/internal/migrations"
 	"github.com/osac-project/osac-operator/pkg/aap"
 	"github.com/osac-project/osac-operator/pkg/provisioning"
 	// +kubebuilder:scaffold:imports
@@ -683,7 +685,9 @@ func main() {
 		remoteProvider = single.New(remoteClusterName, remoteCluster)
 	}
 
-	mgr, err := mcmanager.New(ctrl.GetConfigOrDie(), remoteProvider, manager.Options{
+	cfg := ctrl.GetConfigOrDie()
+
+	mgr, err := mcmanager.New(cfg, remoteProvider, manager.Options{
 		Scheme:                 localScheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
@@ -752,6 +756,18 @@ func main() {
 	}
 
 	// +kubebuilder:scaffold:builder
+
+	// Register data migrations as a leader-election runnable.
+	// Migrations run once after this instance becomes leader.
+	migrationClient, err := client.New(cfg, client.Options{})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for migrations")
+		os.Exit(1)
+	}
+	if err := mgr.GetLocalManager().Add(migrations.NewRunnable(migrationClient)); err != nil {
+		setupLog.Error(err, "unable to register migrations")
+		os.Exit(1)
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/config/crd/bases/osac.openshift.io_computeinstances.yaml
+++ b/config/crd/bases/osac.openshift.io_computeinstances.yaml
@@ -137,7 +137,7 @@ spec:
               networkAttachments:
                 description: |-
                   NetworkAttachments defines multiple NICs when more than one subnet (and optional security groups per NIC) is required.
-                  When non-empty, subnetRef must be empty; the first entry is the primary subnet for VM placement (subnet-namespace annotation).
+                  The first entry is the primary subnet for VM placement (subnet-namespace annotation).
                   Subnet references (per NetworkAttachment) are immutable but security groups can be changed.
 
                   Why immutability is required:
@@ -170,6 +170,7 @@ spec:
                     subnetRef:
                       description: SubnetRef is the name of the Subnet CR in the same
                         namespace as the ComputeInstance.
+                      maxLength: 253
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
@@ -184,8 +185,10 @@ spec:
                 - subnetRef
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: cannot add or remove network attachments
-                  rule: size(self) == size(oldSelf)
+                - message: cannot change or add/remove network attachments after initial
+                    assignment
+                  rule: size(oldSelf) == 0 || (size(self) == size(oldSelf) && self.all(na,
+                    oldSelf.exists(old, old.subnetRef == na.subnetRef)))
               restartRequestedAt:
                 description: |-
                   RestartRequestedAt is a timestamp signal to request a VM restart (MUTABLE).
@@ -214,11 +217,6 @@ spec:
                 x-kubernetes-validations:
                 - message: sshKey is immutable
                   rule: self == oldSelf
-              subnetRef:
-                description: |-
-                  SubnetRef is the name of the Subnet CR in the hub cluster
-                  This references the Kubernetes CR name (not the fulfillment ID)
-                type: string
               templateID:
                 description: TemplateID is the unique identifier of the compute instance
                   template to use when creating this compute instance
@@ -256,10 +254,6 @@ spec:
             - runStrategy
             - templateID
             type: object
-            x-kubernetes-validations:
-            - message: subnetRef must be empty when networkAttachments is set
-              rule: '!(has(self.networkAttachments) && size(self.networkAttachments)
-                > 0 && has(self.subnetRef) && self.subnetRef != "")'
           status:
             description: status defines the observed state of ComputeInstance
             properties:

--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -55,7 +55,7 @@ const (
 )
 
 // errSubnetNotFound is returned when the Subnet CR referenced by the primary
-// subnet (spec.subnetRef or networkAttachments[0].subnetRef) does not exist.
+// subnet (networkAttachments[0].subnetRef) does not exist.
 // handleUpdate treats this as a transient error and requeues with a fixed delay
 // instead of exponential backoff.
 var errSubnetNotFound = errors.New("subnet CR not found")
@@ -592,7 +592,7 @@ func (r *ComputeInstanceReconciler) handleDeprovisioning(ctx context.Context, in
 }
 
 // resolveSubnetTargetNamespace looks up the Subnet CR referenced by the primary subnet
-// (spec.subnetRef or networkAttachments[0].subnetRef) and returns the subnet target
+// (networkAttachments[0].subnetRef) and returns the subnet target
 // namespace (which equals the Subnet CR name).
 // Returns empty string if no primary subnet is set.
 // Returns error if Subnet CR lookup fails.
@@ -629,7 +629,7 @@ func (r *ComputeInstanceReconciler) resolveSubnetTargetNamespace(ctx context.Con
 }
 
 // syncSubnetTargetNamespaceAnnotation ensures the subnet-target-namespace annotation is set
-// when a primary subnet (subnetRef or networkAttachments[0].subnetRef) is configured.
+// when a primary subnet (networkAttachments[0].subnetRef) is configured.
 // The primary subnet reference is immutable, so the annotation only needs to be resolved
 // and written once; subsequent reconciles reuse the cached annotation value.
 // Returns the resolved namespace, whether the annotation was written, and any error.
@@ -658,7 +658,7 @@ func (r *ComputeInstanceReconciler) syncSubnetTargetNamespaceAnnotation(ctx cont
 }
 
 // syncMetadataPreflight ensures the finalizer is set and the subnet-target-namespace
-// annotation is in sync with the current SubnetRef.  It batches all metadata
+// annotation is in sync with the current networkAttachments subnet.  It batches all metadata
 // changes into a single r.Update() call to avoid multiple round-trips and the
 // status-clobbering problem.  The resolved subnetTargetNamespace is returned so
 // callers can reuse it without a second resolveSubnetNamespace call.
@@ -739,7 +739,7 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 		return ctrl.Result{}, err
 	}
 
-	// When a subnetRef is set, the VM is created in the subnet target namespace
+	// When a networkAttachment is set, the VM is created in the subnet target namespace
 	// (by the AAP playbook), not in the tenant target namespace.  Reuse the
 	// value resolved by syncMetadataPreflight to avoid a redundant API call.
 	targetNamespace := tenant.Status.Namespace

--- a/internal/controller/computeinstance_controller_test.go
+++ b/internal/controller/computeinstance_controller_test.go
@@ -2033,7 +2033,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 				},
 				Spec: newTestComputeInstanceSpec("test_template"),
 			}
-			instance.Spec.SubnetRef = subnetRef
+			instance.Spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{{SubnetRef: subnetRef}}
 
 			// Wait for Subnet CR to be cached
 			Eventually(func() error {
@@ -2053,7 +2053,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 				},
 				Spec: newTestComputeInstanceSpec("test_template"),
 			}
-			instance.Spec.SubnetRef = "nonexistent-subnet"
+			instance.Spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{{SubnetRef: "nonexistent-subnet"}}
 
 			subnetNS, err := reconciler.resolveSubnetTargetNamespace(ctx, instance)
 			Expect(err).To(HaveOccurred())
@@ -2108,7 +2108,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 
 			nn := types.NamespacedName{Name: resourceName, Namespace: namespaceName}
 			spec := newTestComputeInstanceSpec("test_template")
-			spec.SubnetRef = subnetRef
+			spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{{SubnetRef: subnetRef}}
 			resource := &osacv1alpha1.ComputeInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
@@ -2149,7 +2149,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 
 			nn := types.NamespacedName{Name: resourceName, Namespace: namespaceName}
 			spec := newTestComputeInstanceSpec("test_template")
-			spec.SubnetRef = "nonexistent-subnet-cr"
+			spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{{SubnetRef: "nonexistent-subnet-cr"}}
 			resource := &osacv1alpha1.ComputeInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
@@ -2207,7 +2207,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 
 			nn := types.NamespacedName{Name: resourceName, Namespace: namespaceName}
 			spec := newTestComputeInstanceSpec("test_template")
-			spec.SubnetRef = subnetRef
+			spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{{SubnetRef: subnetRef}}
 			resource := &osacv1alpha1.ComputeInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
@@ -2268,7 +2268,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 
 			nn := types.NamespacedName{Name: resourceName, Namespace: namespaceName}
 			spec := newTestComputeInstanceSpec("test_template")
-			spec.SubnetRef = subnetRef
+			spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{{SubnetRef: subnetRef}}
 			resource := &osacv1alpha1.ComputeInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
@@ -2563,11 +2563,11 @@ var _ = Describe("ComputeInstance Controller", func() {
 			Expect(spec.PrimarySubnetRef()).To(Equal(""))
 		})
 
-		It("should return subnetRef when subnetRef is set", func() {
+		It("should return empty when networkAttachments is empty", func() {
 			spec := osacv1alpha1.ComputeInstanceSpec{
-				SubnetRef: "test-subnet",
+				NetworkAttachments: []osacv1alpha1.NetworkAttachment{},
 			}
-			Expect(spec.PrimarySubnetRef()).To(Equal("test-subnet"))
+			Expect(spec.PrimarySubnetRef()).To(Equal(""))
 		})
 
 		It("should return networkAttachments[0].subnetRef when networkAttachments is set", func() {

--- a/internal/controller/computeinstance_validation_test.go
+++ b/internal/controller/computeinstance_validation_test.go
@@ -75,41 +75,19 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 		}
 	}
 
-	Describe("Mutual exclusion: subnetRef and networkAttachments", func() {
-		It("should reject creation when both subnetRef and networkAttachments are set", func() {
-			instance := createValidInstance("test-both-subnets")
-			instance.Spec.SubnetRef = "legacy-subnet"
-			instance.Spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{
-				{SubnetRef: "new-subnet"},
-			}
+	It("should allow creation with networkAttachments", func() {
+		instance := createValidInstance("test-network-attachments")
+		instance.Spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{
+			{SubnetRef: "subnet-a"},
+		}
 
-			err := k8sClient.Create(ctx, instance)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsInvalid(err)).To(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("subnetRef must be empty when networkAttachments is set"))
-		})
+		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+	})
 
-		It("should allow creation with only subnetRef", func() {
-			instance := createValidInstance("test-legacy-subnet")
-			instance.Spec.SubnetRef = "legacy-subnet"
+	It("should allow creation without networkAttachments", func() {
+		instance := createValidInstance("test-no-subnets")
 
-			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
-		})
-
-		It("should allow creation with only networkAttachments", func() {
-			instance := createValidInstance("test-network-attachments")
-			instance.Spec.NetworkAttachments = []osacv1alpha1.NetworkAttachment{
-				{SubnetRef: "subnet-a"},
-			}
-
-			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
-		})
-
-		It("should allow creation with neither subnetRef nor networkAttachments", func() {
-			instance := createValidInstance("test-no-subnets")
-
-			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
-		})
+		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
 	})
 
 	Describe("NetworkAttachment immutability", func() {

--- a/internal/migrations/migrate_subnetrefs.go
+++ b/internal/migrations/migrate_subnetrefs.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const envComputeInstanceNamespace = "OSAC_COMPUTE_INSTANCE_NAMESPACE"
+
+// migrateSubnetRefs migrates ComputeInstance CRs from the legacy spec.subnetRef
+// field to spec.networkAttachments[0].subnetRef. It uses the unstructured client
+// to read raw JSON from etcd, which retains the stored subnetRef even after the
+// field is removed from the CRD schema.
+//
+// This function is idempotent: CRs that already have networkAttachments or lack
+// subnetRef are skipped. It is safe for concurrent execution by multiple replicas.
+func migrateSubnetRefs(ctx context.Context, c client.Client) error {
+	log := ctrllog.FromContext(ctx).WithName("migrate-subnetrefs")
+	namespace := os.Getenv(envComputeInstanceNamespace)
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "osac.openshift.io",
+		Version: "v1alpha1",
+		Kind:    "ComputeInstanceList",
+	})
+
+	listOpts := []client.ListOption{}
+	if namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(namespace))
+	}
+	if err := c.List(ctx, list, listOpts...); err != nil {
+		return fmt.Errorf("failed to list ComputeInstances for migration: %w", err)
+	}
+
+	migrated := 0
+	for i := range list.Items {
+		item := &list.Items[i]
+		spec, _ := item.Object["spec"].(map[string]interface{})
+		if spec == nil {
+			continue
+		}
+
+		subnetRef, _ := spec["subnetRef"].(string)
+		if subnetRef == "" {
+			continue
+		}
+
+		if na, ok := spec["networkAttachments"]; ok {
+			if naSlice, ok := na.([]interface{}); ok && len(naSlice) > 0 {
+				continue
+			}
+		}
+
+		mergePatch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"networkAttachments": []map[string]interface{}{
+					{"subnetRef": subnetRef},
+				},
+			},
+		}
+		patchBytes, err := json.Marshal(mergePatch)
+		if err != nil {
+			return fmt.Errorf("failed to marshal patch for %s/%s: %w",
+				item.GetNamespace(), item.GetName(), err)
+		}
+
+		if err := c.Patch(ctx, item, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
+			return fmt.Errorf("failed to migrate %s/%s: %w",
+				item.GetNamespace(), item.GetName(), err)
+		}
+
+		migrated++
+		log.Info("Migrated ComputeInstance from subnetRef to networkAttachments",
+			"namespace", item.GetNamespace(),
+			"name", item.GetName(),
+			"subnetRef", subnetRef,
+		)
+	}
+
+	if migrated > 0 {
+		log.Info("SubnetRef migration complete", "migrated", migrated)
+	}
+	return nil
+}

--- a/internal/migrations/migrate_subnetrefs_test.go
+++ b/internal/migrations/migrate_subnetrefs_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrations
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newUnstructuredCI(name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "osac.openshift.io/v1alpha1",
+			"kind":       "ComputeInstance",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func ciSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"templateID":  "test_template",
+		"cores":       int64(4),
+		"memoryGiB":   int64(8),
+		"runStrategy": "Always",
+		"image": map[string]interface{}{
+			"sourceType": "registry",
+			"sourceRef":  "quay.io/fedora/fedora-coreos:stable",
+		},
+		"bootDisk": map[string]interface{}{
+			"sizeGiB": int64(30),
+		},
+	}
+}
+
+var ciGVK = schema.GroupVersionKind{
+	Group: "osac.openshift.io", Version: "v1alpha1", Kind: "ComputeInstance",
+}
+
+func getSubnetRefFromNA(obj *unstructured.Unstructured, index int) string {
+	na, found, _ := unstructured.NestedSlice(obj.Object, "spec", "networkAttachments")
+	if !found || index >= len(na) {
+		return ""
+	}
+	entry, ok := na[index].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	ref, _ := entry["subnetRef"].(string)
+	return ref
+}
+
+var _ = Describe("migrateSubnetRefs", func() {
+	var s *runtime.Scheme
+
+	BeforeEach(func() {
+		s = runtime.NewScheme()
+		s.AddKnownTypeWithName(ciGVK, &unstructured.Unstructured{})
+		s.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: "osac.openshift.io", Version: "v1alpha1", Kind: "ComputeInstanceList"},
+			&unstructured.UnstructuredList{},
+		)
+		os.Setenv(envComputeInstanceNamespace, "default")
+	})
+
+	AfterEach(func() {
+		os.Unsetenv(envComputeInstanceNamespace)
+	})
+
+	It("should migrate a CR with subnetRef to networkAttachments", func() {
+		spec := ciSpec()
+		spec["subnetRef"] = "legacy-subnet"
+
+		fc := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(newUnstructuredCI("migrate-legacy", "default", spec)).
+			Build()
+
+		Expect(migrateSubnetRefs(ctx, fc)).To(Succeed())
+
+		result := &unstructured.Unstructured{}
+		result.SetGroupVersionKind(ciGVK)
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "migrate-legacy", Namespace: "default"}, result)).To(Succeed())
+
+		na, found, err := unstructured.NestedSlice(result.Object, "spec", "networkAttachments")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(na).To(HaveLen(1))
+		Expect(getSubnetRefFromNA(result, 0)).To(Equal("legacy-subnet"))
+	})
+
+	It("should not modify a CR that already has networkAttachments", func() {
+		spec := ciSpec()
+		spec["networkAttachments"] = []interface{}{
+			map[string]interface{}{"subnetRef": "existing-subnet"},
+		}
+
+		fc := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(newUnstructuredCI("already-migrated", "default", spec)).
+			Build()
+
+		Expect(migrateSubnetRefs(ctx, fc)).To(Succeed())
+
+		result := &unstructured.Unstructured{}
+		result.SetGroupVersionKind(ciGVK)
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "already-migrated", Namespace: "default"}, result)).To(Succeed())
+		Expect(getSubnetRefFromNA(result, 0)).To(Equal("existing-subnet"))
+	})
+
+	It("should not modify a CR with neither subnetRef nor networkAttachments", func() {
+		fc := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(newUnstructuredCI("no-subnet", "default", ciSpec())).
+			Build()
+
+		Expect(migrateSubnetRefs(ctx, fc)).To(Succeed())
+
+		result := &unstructured.Unstructured{}
+		result.SetGroupVersionKind(ciGVK)
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "no-subnet", Namespace: "default"}, result)).To(Succeed())
+
+		_, found, _ := unstructured.NestedSlice(result.Object, "spec", "networkAttachments")
+		Expect(found).To(BeFalse())
+	})
+
+	It("should migrate only legacy CRs in a mixed batch", func() {
+		legacySpec := ciSpec()
+		legacySpec["subnetRef"] = "legacy-subnet-1"
+
+		modernSpec := ciSpec()
+		modernSpec["networkAttachments"] = []interface{}{
+			map[string]interface{}{"subnetRef": "modern-subnet"},
+		}
+
+		fc := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(
+				newUnstructuredCI("batch-legacy", "default", legacySpec),
+				newUnstructuredCI("batch-modern", "default", modernSpec),
+				newUnstructuredCI("batch-none", "default", ciSpec()),
+			).
+			Build()
+
+		Expect(migrateSubnetRefs(ctx, fc)).To(Succeed())
+
+		legacy := &unstructured.Unstructured{}
+		legacy.SetGroupVersionKind(ciGVK)
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "batch-legacy", Namespace: "default"}, legacy)).To(Succeed())
+		Expect(getSubnetRefFromNA(legacy, 0)).To(Equal("legacy-subnet-1"))
+
+		modern := &unstructured.Unstructured{}
+		modern.SetGroupVersionKind(ciGVK)
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "batch-modern", Namespace: "default"}, modern)).To(Succeed())
+		Expect(getSubnetRefFromNA(modern, 0)).To(Equal("modern-subnet"))
+
+		none := &unstructured.Unstructured{}
+		none.SetGroupVersionKind(ciGVK)
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "batch-none", Namespace: "default"}, none)).To(Succeed())
+		_, found, _ := unstructured.NestedSlice(none.Object, "spec", "networkAttachments")
+		Expect(found).To(BeFalse())
+	})
+
+	It("should be idempotent — second run migrates nothing", func() {
+		spec := ciSpec()
+		spec["subnetRef"] = "idem-subnet"
+
+		fc := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(newUnstructuredCI("idem-test", "default", spec)).
+			Build()
+
+		Expect(migrateSubnetRefs(ctx, fc)).To(Succeed())
+		Expect(migrateSubnetRefs(ctx, fc)).To(Succeed())
+
+		result := &unstructured.Unstructured{}
+		result.SetGroupVersionKind(ciGVK)
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "idem-test", Namespace: "default"}, result)).To(Succeed())
+
+		na, found, _ := unstructured.NestedSlice(result.Object, "spec", "networkAttachments")
+		Expect(found).To(BeTrue())
+		Expect(na).To(HaveLen(1))
+		Expect(getSubnetRefFromNA(result, 0)).To(Equal("idem-subnet"))
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package migrations contains idempotent data migrations that run at operator startup.
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const migrationTimeout = 5 * time.Minute
+
+// Migration is a named, idempotent data migration that runs at operator startup.
+// Each migration reads its own configuration (e.g. namespace) from environment
+// variables so RunAll doesn't need resource-specific parameters.
+type Migration struct {
+	Name string
+	Fn   func(ctx context.Context, c client.Client) error
+}
+
+// all is the ordered list of migrations. Append new migrations at the end.
+var all = []Migration{
+	{Name: "migrate-subnetrefs", Fn: migrateSubnetRefs},
+}
+
+// runAll executes all registered migrations in order. Each migration is
+// idempotent — safe to re-run on restart. Returns on the first error so the
+// operator fails to start and retries on the next restart.
+func runAll(ctx context.Context, c client.Client) error {
+	log := ctrllog.FromContext(ctx).WithName("migrations")
+
+	ctx, cancel := context.WithTimeout(ctx, migrationTimeout)
+	defer cancel()
+
+	for _, m := range all {
+		log.Info("Running migration", "name", m.Name)
+		if err := m.Fn(ctx, c); err != nil {
+			return fmt.Errorf("migration %s failed: %w", m.Name, err)
+		}
+	}
+	return nil
+}
+
+// leaderRunnable wraps runAll as a controller-runtime Runnable that requires
+// leader election. The manager calls Start once after this instance becomes
+// leader, ensuring migrations run on exactly one replica.
+type leaderRunnable struct {
+	client client.Client
+}
+
+func (r *leaderRunnable) Start(ctx context.Context) error {
+	return runAll(ctx, r.client)
+}
+
+func (r *leaderRunnable) NeedLeaderElection() bool {
+	return true
+}
+
+// NewRunnable returns a manager.Runnable that executes all migrations once
+// after leader election. Register it with mgr.Add().
+func NewRunnable(c client.Client) manager.Runnable {
+	return &leaderRunnable{client: c}
+}

--- a/internal/migrations/migrations_suite_test.go
+++ b/internal/migrations/migrations_suite_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+)
+
+var ctx context.Context
+
+func TestMigrations(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Migrations Suite")
+}
+
+var _ = BeforeSuite(func() {
+	ctx = context.Background()
+})


### PR DESCRIPTION
Remove the deprecated spec.subnetRef field from ComputeInstanceSpec, completing the migration to the networkAttachments array for multi-NIC VM support. This aligns with the fulfillment-service (PR 565) which already removed its equivalent proto fields.

Changes:
- Remove SubnetRef field and mutual-exclusion CEL validation rule
- Relax networkAttachments size rule to allow initial population (0→N) while still preventing subsequent add/remove
- Add startup migration (internal/migrations) that patches legacy CRs using unstructured client to read stored subnetRef from etcd
- Migration runs as LeaderElectionRunnable — only the leader executes
- Update PrimarySubnetRef() to return empty string instead of legacy fallback
- Update controller comments and tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic startup migration that converts legacy single-NIC configs into the new multi-NIC networkAttachments format.

* **Behavior / Schema Changes**
  * Primary subnet is now taken from the first networkAttachments entry.
  * networkAttachments may be initially set from empty to non-empty; subsequent add/remove remains disallowed.
  * Legacy single-NIC subnetRef field removed from the schema.

* **Breaking Changes**
  * Legacy subnetRef removed — configure compute instances using networkAttachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->