### PR TITLE
NO-ISSUE: Sync Go 1.26.3 pins in Makefile and api module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ CONTAINERFILE ?= Containerfile
 ENVTEST_K8S_VERSION = 1.31.0
 
 # Go version for local make targets. Keep in sync with go.mod.
-GO_VERSION ?= 1.26.2
+GO_VERSION ?= 1.26.3
 GOTOOLCHAIN ?= go$(GO_VERSION)
 GOTOOLCHAIN_AUTO ?= $(GOTOOLCHAIN)+auto
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/osac-project/osac-operator/api
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1


### PR DESCRIPTION
## Summary

- Bump `Makefile` `GO_VERSION` from `1.26.2` to `1.26.3` (keep in sync with root `go.mod`)
- Bump nested `api/go.mod` `go` directive from `1.25.0` to `1.26.3`

Follow-up to dependabot #277, which updated root `go.mod` only.

## Scope

Version-line alignment only — no `api/` dependency bumps and no new `api/v0.0.x` tag (that would be a separate consumer-facing change for fulfillment-service).

## Test plan

- [x] `go test ./...` in `api/`
- [x] `make fmt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->