### PR TITLE
OSAC-244: document compute-instance-operations-ig secret for VMaaS

### DIFF
--- a/docs/vmaas-dedicated-cluster/README.md
+++ b/docs/vmaas-dedicated-cluster/README.md
@@ -138,6 +138,10 @@ Pass `REMOTE_CLUSTER_KUBECONFIG_SECRET_NAME=<secret-name>` to the
 config-as-code job (or set it in the relevant config vars). The Secret must
 be readable by the `osac-sa` service account in the AAP namespace.
 
+Create a `compute-instance-operations-ig` Secret for VM/MOC credentials
+(OpenStack application credentials when required). See
+`osac-aap/config/base/secret-compute-instance-operations-ig-example.yaml`.
+
 ## References
 
 - [MGMT-23102](https://redhat.atlassian.net/browse/MGMT-23102) — Add the


### PR DESCRIPTION
## Summary

Add VMaaS documentation for the dedicated `compute-instance-operations-ig` secret (OpenStack application credentials for VM/MOC scenarios).

## Jira

https://redhat.atlassian.net/browse/OSAC-244

## Cross-repo

Companion PRs:
- [osac-aap#331](https://github.com/osac-project/osac-aap/pull/331)
- [osac-installer#223](https://github.com/osac-project/osac-installer/pull/223) (submodule bump depends on this commit being fetchable)

## Test plan

- [x] Docs-only change