### PR TITLE
OSAC-1281: Add exponential backoff retry for failed deprovision jobs

### DIFF
--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -571,6 +571,10 @@ func (r *ClusterOrderReconciler) handleDeprovisioning(ctx context.Context, insta
 		ctrllog.FromContext(ctx).Info("skipping deprovisioning due to management-state annotation", "management-state", val)
 		return ctrl.Result{}, nil
 	}
+	if r.ProvisioningProvider == nil {
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping deprovisioning")
+		return ctrl.Result{}, nil
+	}
 	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, instance,
 		&instance.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
 	if err != nil || !done {

--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -566,29 +566,15 @@ func (r *ClusterOrderReconciler) handleDesiredConfigVersion(instance *v1alpha1.C
 // handleDeprovisioning manages the deprovisioning job lifecycle for ClusterOrder.
 // Waits for provision job termination if needed, then triggers deprovision job.
 func (r *ClusterOrderReconciler) handleDeprovisioning(ctx context.Context, instance *v1alpha1.ClusterOrder) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
-	// Check for ManagementStateManual annotation
 	val, exists := instance.Annotations[osacManagementStateAnnotation]
 	if exists && val == ManagementStateManual {
-		log.Info("skipping deprovisioning due to management-state annotation", "management-state", val)
+		ctrllog.FromContext(ctx).Info("skipping deprovisioning due to management-state annotation", "management-state", val)
 		return ctrl.Result{}, nil
 	}
-
-	latestDeprovisionJob := provisioning.FindLatestJobByType(instance.Status.Jobs, v1alpha1.JobTypeDeprovision)
-
-	if !provisioning.HasJobID(latestDeprovisionJob) {
-		return provisioning.TriggerDeprovisionJob(ctx, r.ProvisioningProvider, instance,
-			&instance.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
-	}
-
-	result, done, err := provisioning.PollDeprovisionJob(ctx, r.ProvisioningProvider, instance,
-		&instance.Status.Jobs, latestDeprovisionJob, r.StatusPollInterval)
-	if err != nil {
+	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, instance,
+		&instance.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
+	if err != nil || !done {
 		return result, err
-	}
-	if !done {
-		return result, nil
 	}
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/clusterorder_integration_test.go
+++ b/internal/controller/clusterorder_integration_test.go
@@ -223,7 +223,8 @@ var _ = Describe("ClusterOrder Integration Tests", func() {
 			instance = getClusterOrder(name)
 			result, err := reconciler.handleDeprovisioning(ctx, instance)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(statusPollInterval), "should requeue to block deletion")
+			Expect(result.RequeueAfter).To(BeNumerically("<=", provisioning.BackoffBaseDelay), "should wait for backoff before retry")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 		})
 	})
 

--- a/internal/controller/publicip_controller.go
+++ b/internal/controller/publicip_controller.go
@@ -361,86 +361,15 @@ func (r *PublicIPReconciler) handleProvisioning(ctx context.Context, publicIP *v
 // and polls its status. On failure, it either blocks deletion (to prevent orphaned
 // resources) or allows the process to continue, depending on provider policy.
 func (r *PublicIPReconciler) handleDeprovisioning(ctx context.Context, publicIP *v1alpha1.PublicIP) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
 	if r.ProvisioningProvider == nil {
-		log.Info("no provisioning provider configured, skipping deprovisioning")
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping deprovisioning")
 		return ctrl.Result{}, nil
 	}
-
-	latestDeprovisionJob := provisioning.FindLatestJobByType(publicIP.Status.Jobs, v1alpha1.JobTypeDeprovision)
-
-	// Trigger a new deprovisioning job if none exists yet
-	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
-		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
-
-		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, publicIP)
-		if err != nil {
-			log.Error(err, "failed to trigger deprovisioning")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
-
-		switch result.Action {
-		case provisioning.DeprovisionWaiting:
-			log.Info("deprovisioning not ready, requeueing")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-
-		case provisioning.DeprovisionSkipped:
-			log.Info("provider skipped deprovisioning")
-			return ctrl.Result{}, nil
-
-		case provisioning.DeprovisionTriggered:
-			newJob := v1alpha1.JobStatus{
-				JobID:                  result.JobID,
-				Type:                   v1alpha1.JobTypeDeprovision,
-				Timestamp:              metav1.NewTime(time.Now().UTC()),
-				State:                  v1alpha1.JobStatePending,
-				Message:                deprovisioningJobTriggeredMessage,
-				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
-			}
-			publicIP.Status.Jobs = provisioning.AppendJob(publicIP.Status.Jobs, newJob, r.MaxJobHistory)
-			log.Info("deprovisioning job triggered", "jobID", result.JobID)
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
+	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, publicIP,
+		&publicIP.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
+	if err != nil || !done {
+		return result, err
 	}
-
-	// Poll the existing deprovisioning job
-	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, publicIP, latestDeprovisionJob.JobID)
-	if err != nil {
-		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
-		updatedJob := *latestDeprovisionJob
-		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
-		provisioning.UpdateJob(publicIP.Status.Jobs, updatedJob)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	updatedJob := *latestDeprovisionJob
-	updatedJob.State = status.State
-	updatedJob.Message = status.MessageWithDetails()
-	provisioning.UpdateJob(publicIP.Status.Jobs, updatedJob)
-
-	if !status.State.IsTerminal() {
-		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	if status.State.IsSuccessful() {
-		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
-		return ctrl.Result{}, nil
-	}
-
-	if latestDeprovisionJob.BlockDeletionOnFailure {
-		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	log.Info("deprovision job did not succeed, allowing process to continue",
-		"jobID", latestDeprovisionJob.JobID,
-		"state", status.State,
-		"message", updatedJob.Message)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/publicipattachment_controller.go
+++ b/internal/controller/publicipattachment_controller.go
@@ -493,88 +493,15 @@ func (r *PublicIPAttachmentReconciler) maybeRemoveCIDetachFinalizer(ctx context.
 }
 
 func (r *PublicIPAttachmentReconciler) handleDeprovisioning(ctx context.Context, attachment *v1alpha1.PublicIPAttachment) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
 	if r.ProvisioningProvider == nil {
-		log.Info("no provisioning provider configured, skipping deprovisioning")
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping deprovisioning")
 		return ctrl.Result{}, nil
 	}
-
-	latestDeprovisionJob := provisioning.FindLatestJobByType(attachment.Status.Jobs, v1alpha1.JobTypeDeprovision)
-
-	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
-		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
-
-		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, attachment)
-		if err != nil {
-			log.Error(err, "failed to trigger deprovisioning")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
-
-		switch result.Action {
-		case provisioning.DeprovisionWaiting:
-			log.Info("deprovisioning not ready, requeueing")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-
-		case provisioning.DeprovisionSkipped:
-			log.Info("provider skipped deprovisioning")
-			return ctrl.Result{}, nil
-
-		case provisioning.DeprovisionTriggered:
-			newJob := v1alpha1.JobStatus{
-				JobID:                  result.JobID,
-				Type:                   v1alpha1.JobTypeDeprovision,
-				Timestamp:              metav1.NewTime(time.Now().UTC()),
-				State:                  v1alpha1.JobStatePending,
-				Message:                deprovisioningJobTriggeredMessage,
-				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
-			}
-			attachment.Status.Jobs = provisioning.AppendJob(attachment.Status.Jobs, newJob, r.MaxJobHistory)
-			log.Info("deprovisioning job triggered", "jobID", result.JobID)
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-
-		default:
-			log.Info("unexpected deprovision action, requeueing", "action", result.Action)
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
+	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, attachment,
+		&attachment.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
+	if err != nil || !done {
+		return result, err
 	}
-
-	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, attachment, latestDeprovisionJob.JobID)
-	if err != nil {
-		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
-		updatedJob := *latestDeprovisionJob
-		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
-		provisioning.UpdateJob(attachment.Status.Jobs, updatedJob)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	updatedJob := *latestDeprovisionJob
-	updatedJob.State = status.State
-	updatedJob.Message = status.MessageWithDetails()
-	provisioning.UpdateJob(attachment.Status.Jobs, updatedJob)
-
-	if !status.State.IsTerminal() {
-		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	if status.State.IsSuccessful() {
-		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
-		return ctrl.Result{}, nil
-	}
-
-	if latestDeprovisionJob.BlockDeletionOnFailure {
-		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	log.Info("deprovision job did not succeed, allowing process to continue",
-		"jobID", latestDeprovisionJob.JobID,
-		"state", status.State,
-		"message", updatedJob.Message)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/publicippool_controller.go
+++ b/internal/controller/publicippool_controller.go
@@ -251,93 +251,15 @@ func (r *PublicIPPoolReconciler) handleProvisioning(ctx context.Context, pool *v
 // and polls its status. On failure, it either blocks deletion (to prevent orphaned
 // resources) or allows the process to continue, depending on provider policy.
 func (r *PublicIPPoolReconciler) handleDeprovisioning(ctx context.Context, pool *v1alpha1.PublicIPPool) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
-	// If no provider configured, skip deprovisioning
 	if r.ProvisioningProvider == nil {
-		log.Info("no provisioning provider configured, skipping deprovisioning")
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping deprovisioning")
 		return ctrl.Result{}, nil
 	}
-
-	// Check if we already have a deprovision job
-	latestDeprovisionJob := provisioning.FindLatestJobByType(pool.Status.Jobs, v1alpha1.JobTypeDeprovision)
-
-	// Trigger deprovisioning
-	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
-		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
-
-		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, pool)
-		if err != nil {
-			log.Error(err, "failed to trigger deprovisioning")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
-
-		// Handle provider action
-		switch result.Action {
-		case provisioning.DeprovisionWaiting:
-			log.Info("deprovisioning not ready, requeueing")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-
-		case provisioning.DeprovisionSkipped:
-			log.Info("provider skipped deprovisioning")
-			return ctrl.Result{}, nil
-
-		case provisioning.DeprovisionTriggered:
-			newJob := v1alpha1.JobStatus{
-				JobID:                  result.JobID,
-				Type:                   v1alpha1.JobTypeDeprovision,
-				Timestamp:              metav1.NewTime(time.Now().UTC()),
-				State:                  v1alpha1.JobStatePending,
-				Message:                deprovisioningJobTriggeredMessage,
-				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
-			}
-			pool.Status.Jobs = provisioning.AppendJob(pool.Status.Jobs, newJob, r.MaxJobHistory)
-			log.Info("deprovisioning job triggered", "jobID", result.JobID)
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
+	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, pool,
+		&pool.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
+	if err != nil || !done {
+		return result, err
 	}
-
-	// We have a job ID, check its status
-	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, pool, latestDeprovisionJob.JobID)
-	if err != nil {
-		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
-		updatedJob := *latestDeprovisionJob
-		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
-		provisioning.UpdateJob(pool.Status.Jobs, updatedJob)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Update job status
-	updatedJob := *latestDeprovisionJob
-	updatedJob.State = status.State
-	updatedJob.Message = status.MessageWithDetails()
-	provisioning.UpdateJob(pool.Status.Jobs, updatedJob)
-
-	// If job is still running, requeue
-	if !status.State.IsTerminal() {
-		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Job reached terminal state
-	if status.State.IsSuccessful() {
-		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
-		return ctrl.Result{}, nil
-	}
-
-	// Job failed or was canceled, check policy
-	if latestDeprovisionJob.BlockDeletionOnFailure {
-		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	log.Info("deprovision job did not succeed, allowing process to continue",
-		"jobID", latestDeprovisionJob.JobID,
-		"state", status.State,
-		"message", updatedJob.Message)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/securitygroup_controller.go
+++ b/internal/controller/securitygroup_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -260,93 +259,15 @@ func (r *SecurityGroupReconciler) handleProvisioning(ctx context.Context, sg *v1
 // handleDeprovisioning manages the deprovisioning job lifecycle for a SecurityGroup.
 // It triggers deprovisioning if needed and polls job status until completion.
 func (r *SecurityGroupReconciler) handleDeprovisioning(ctx context.Context, sg *v1alpha1.SecurityGroup) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
-	// If no provider configured, skip deprovisioning
 	if r.ProvisioningProvider == nil {
-		log.Info("no provisioning provider configured, skipping deprovisioning")
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping deprovisioning")
 		return ctrl.Result{}, nil
 	}
-
-	// Check if we already have a deprovision job
-	latestDeprovisionJob := provisioning.FindLatestJobByType(sg.Status.Jobs, v1alpha1.JobTypeDeprovision)
-
-	// Trigger deprovisioning
-	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
-		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
-
-		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, sg)
-		if err != nil {
-			log.Error(err, "failed to trigger deprovisioning")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
-
-		// Handle provider action
-		switch result.Action {
-		case provisioning.DeprovisionWaiting:
-			log.Info("deprovisioning not ready, requeueing")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-
-		case provisioning.DeprovisionSkipped:
-			log.Info("provider skipped deprovisioning")
-			return ctrl.Result{}, nil
-
-		case provisioning.DeprovisionTriggered:
-			newJob := v1alpha1.JobStatus{
-				JobID:                  result.JobID,
-				Type:                   v1alpha1.JobTypeDeprovision,
-				Timestamp:              metav1.NewTime(time.Now().UTC()),
-				State:                  v1alpha1.JobStatePending,
-				Message:                deprovisioningJobTriggeredMessage,
-				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
-			}
-			sg.Status.Jobs = provisioning.AppendJob(sg.Status.Jobs, newJob, r.MaxJobHistory)
-			log.Info("deprovisioning job triggered", "jobID", result.JobID)
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
+	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, sg,
+		&sg.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
+	if err != nil || !done {
+		return result, err
 	}
-
-	// We have a job ID, check its status
-	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, sg, latestDeprovisionJob.JobID)
-	if err != nil {
-		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
-		updatedJob := *latestDeprovisionJob
-		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
-		provisioning.UpdateJob(sg.Status.Jobs, updatedJob)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Update job status
-	updatedJob := *latestDeprovisionJob
-	updatedJob.State = status.State
-	updatedJob.Message = status.MessageWithDetails()
-	provisioning.UpdateJob(sg.Status.Jobs, updatedJob)
-
-	// If job is still running, requeue
-	if !status.State.IsTerminal() {
-		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Job reached terminal state
-	if status.State.IsSuccessful() {
-		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
-		return ctrl.Result{}, nil
-	}
-
-	// Job failed or was canceled - check policy
-	if latestDeprovisionJob.BlockDeletionOnFailure {
-		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	log.Info("deprovision job did not succeed, allowing process to continue",
-		"jobID", latestDeprovisionJob.JobID,
-		"state", status.State,
-		"message", updatedJob.Message)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/subnet_controller.go
+++ b/internal/controller/subnet_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -287,95 +286,14 @@ func (r *SubnetReconciler) handleProvisioning(ctx context.Context, subnet *v1alp
 // handleDeprovisioning manages the deprovisioning job lifecycle for a Subnet.
 // It triggers deprovisioning if needed and polls job status until completion.
 func (r *SubnetReconciler) handleDeprovisioning(ctx context.Context, subnet *v1alpha1.Subnet) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
-	// If no provider configured, skip deprovisioning
 	if r.ProvisioningProvider == nil {
-		log.Info("no provisioning provider configured, skipping deprovisioning")
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping deprovisioning")
 		return ctrl.Result{}, nil
 	}
-
-	// Check if we already have a deprovision job
-	latestDeprovisionJob := provisioning.FindLatestJobByType(subnet.Status.Jobs, v1alpha1.JobTypeDeprovision)
-
-	// Trigger deprovisioning - provider decides internally if ready
-	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
-		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
-
-		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, subnet)
-		if err != nil {
-			log.Error(err, "failed to trigger deprovisioning")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
-
-		// Handle provider action
-		switch result.Action {
-		case provisioning.DeprovisionWaiting:
-			log.Info("deprovisioning not ready, requeueing")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-
-		case provisioning.DeprovisionSkipped:
-			log.Info("provider skipped deprovisioning")
-			return ctrl.Result{}, nil
-
-		case provisioning.DeprovisionTriggered:
-			newJob := v1alpha1.JobStatus{
-				JobID:                  result.JobID,
-				Type:                   v1alpha1.JobTypeDeprovision,
-				Timestamp:              metav1.NewTime(time.Now().UTC()),
-				State:                  v1alpha1.JobStatePending,
-				Message:                deprovisioningJobTriggeredMessage,
-				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
-			}
-			subnet.Status.Jobs = provisioning.AppendJob(subnet.Status.Jobs, newJob, r.MaxJobHistory)
-			log.Info("deprovisioning job triggered", "jobID", result.JobID)
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
+	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, subnet,
+		&subnet.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
+	if err != nil || !done {
+		return result, err
 	}
-
-	// We have a job ID, check its status
-	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, subnet, latestDeprovisionJob.JobID)
-	if err != nil {
-		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
-		updatedJob := *latestDeprovisionJob
-		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
-		provisioning.UpdateJob(subnet.Status.Jobs, updatedJob)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Update job status
-	updatedJob := *latestDeprovisionJob
-	updatedJob.State = status.State
-	updatedJob.Message = status.MessageWithDetails()
-	provisioning.UpdateJob(subnet.Status.Jobs, updatedJob)
-
-	// If job is still running, requeue
-	if !status.State.IsTerminal() {
-		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Job reached terminal state (Succeeded, Failed, or Canceled)
-	if status.State.IsSuccessful() {
-		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
-		return ctrl.Result{}, nil
-	}
-
-	// Job failed or was canceled
-	// Check policy stored in job status
-	if latestDeprovisionJob.BlockDeletionOnFailure {
-		// Block deletion to prevent orphaned resources
-		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	} else {
-		// Allow process to continue
-		log.Info("deprovision job did not succeed, allowing process to continue",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{}, nil
-	}
+	return ctrl.Result{}, nil
 }

--- a/internal/controller/subnet_controller_test.go
+++ b/internal/controller/subnet_controller_test.go
@@ -588,7 +588,7 @@ var _ = Describe("SubnetReconciler", func() {
 			Expect(result.RequeueAfter).To(Equal(0 * time.Second))
 		})
 
-		It("should block deletion when deprovision fails with BlockDeletionOnFailure", func() {
+		It("should wait for backoff when deprovision fails with BlockDeletionOnFailure", func() {
 			subnet.Status.Jobs = []osacv1alpha1.JobStatus{
 				{
 					JobID:                  "deprovision-failed-505",
@@ -610,7 +610,8 @@ var _ = Describe("SubnetReconciler", func() {
 
 			result, err := reconciler.handleDeprovisioning(ctx, subnet)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+			Expect(result.RequeueAfter).To(BeNumerically("<=", provisioning.BackoffBaseDelay))
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 		})
 	})
 })

--- a/internal/controller/virtualnetwork_controller.go
+++ b/internal/controller/virtualnetwork_controller.go
@@ -247,6 +247,10 @@ func (r *VirtualNetworkReconciler) handleDelete(ctx context.Context, vnet *v1alp
 // handleDeprovisioning manages the deprovisioning job lifecycle for a VirtualNetwork.
 // It triggers deprovisioning if needed and polls job status until completion.
 func (r *VirtualNetworkReconciler) handleDeprovisioning(ctx context.Context, vnet *v1alpha1.VirtualNetwork) (ctrl.Result, error) {
+	if r.ProvisioningProvider == nil {
+		ctrllog.FromContext(ctx).Info("no provisioning provider configured, skipping deprovisioning")
+		return ctrl.Result{}, nil
+	}
 	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, vnet,
 		&vnet.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
 	if err != nil || !done {

--- a/internal/controller/virtualnetwork_controller.go
+++ b/internal/controller/virtualnetwork_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -248,91 +247,12 @@ func (r *VirtualNetworkReconciler) handleDelete(ctx context.Context, vnet *v1alp
 // handleDeprovisioning manages the deprovisioning job lifecycle for a VirtualNetwork.
 // It triggers deprovisioning if needed and polls job status until completion.
 func (r *VirtualNetworkReconciler) handleDeprovisioning(ctx context.Context, vnet *v1alpha1.VirtualNetwork) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
-	// Check if we already have a deprovision job
-	latestDeprovisionJob := provisioning.FindLatestJobByType(vnet.Status.Jobs, v1alpha1.JobTypeDeprovision)
-
-	// Trigger deprovisioning - provider decides internally if ready
-	if latestDeprovisionJob == nil || latestDeprovisionJob.JobID == "" {
-		log.Info("triggering deprovisioning", "provider", r.ProvisioningProvider.Name())
-
-		result, err := r.ProvisioningProvider.TriggerDeprovision(ctx, vnet)
-		if err != nil {
-			log.Error(err, "failed to trigger deprovisioning")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
-
-		// Handle provider action
-		switch result.Action {
-		case provisioning.DeprovisionWaiting:
-			log.Info("deprovisioning not ready, requeueing")
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-
-		case provisioning.DeprovisionSkipped:
-			log.Info("provider skipped deprovisioning")
-			return ctrl.Result{}, nil
-
-		case provisioning.DeprovisionTriggered:
-			newJob := v1alpha1.JobStatus{
-				JobID:                  result.JobID,
-				Type:                   v1alpha1.JobTypeDeprovision,
-				Timestamp:              metav1.NewTime(time.Now().UTC()),
-				State:                  v1alpha1.JobStatePending,
-				Message:                deprovisioningJobTriggeredMessage,
-				BlockDeletionOnFailure: result.BlockDeletionOnFailure,
-			}
-			vnet.Status.Jobs = provisioning.AppendJob(vnet.Status.Jobs, newJob, r.MaxJobHistory)
-			log.Info("deprovisioning job triggered", "jobID", result.JobID)
-			return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-		}
+	result, done, err := provisioning.RunDeprovisioningLifecycle(ctx, r.ProvisioningProvider, vnet,
+		&vnet.Status.Jobs, r.MaxJobHistory, r.StatusPollInterval)
+	if err != nil || !done {
+		return result, err
 	}
-
-	// We have a job ID, check its status
-	status, err := r.ProvisioningProvider.GetDeprovisionStatus(ctx, vnet, latestDeprovisionJob.JobID)
-	if err != nil {
-		log.Error(err, "failed to get deprovision job status", "jobID", latestDeprovisionJob.JobID)
-		updatedJob := *latestDeprovisionJob
-		updatedJob.Message = fmt.Sprintf("Failed to get job status: %v", err)
-		provisioning.UpdateJob(vnet.Status.Jobs, updatedJob)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Update job status
-	updatedJob := *latestDeprovisionJob
-	updatedJob.State = status.State
-	updatedJob.Message = status.MessageWithDetails()
-	provisioning.UpdateJob(vnet.Status.Jobs, updatedJob)
-
-	// If job is still running, requeue
-	if !status.State.IsTerminal() {
-		log.Info("deprovision job still running", "jobID", latestDeprovisionJob.JobID, "state", status.State)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	}
-
-	// Job reached terminal state (Succeeded, Failed, or Canceled)
-	if status.State.IsSuccessful() {
-		log.Info("deprovision job succeeded", "jobID", latestDeprovisionJob.JobID)
-		return ctrl.Result{}, nil
-	}
-
-	// Job failed or was canceled
-	// Check policy stored in job status
-	if latestDeprovisionJob.BlockDeletionOnFailure {
-		// Block deletion to prevent orphaned resources
-		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
-	} else {
-		// Allow process to continue
-		log.Info("deprovision job did not succeed, allowing process to continue",
-			"jobID", latestDeprovisionJob.JobID,
-			"state", status.State,
-			"message", updatedJob.Message)
-		return ctrl.Result{}, nil
-	}
+	return ctrl.Result{}, nil
 }
 
 // updateStatusWithRetry updates the virtual network status with retry on conflict.

--- a/pkg/provisioning/provision_helpers.go
+++ b/pkg/provisioning/provision_helpers.go
@@ -79,15 +79,14 @@ func HasJobID(job *v1alpha1.JobStatus) bool {
 	return job != nil && job.JobID != ""
 }
 
-// ComputeBackoffFromJobs determines the next backoff duration based on the gap
-// between the last two failed provision jobs with the same ConfigVersion.
+// computeBackoffFromFailedJobs determines the next backoff duration based on the gap
+// between the last two failed jobs matching the filter.
 // First failure uses BackoffBaseDelay. Subsequent failures double the previous gap.
-func ComputeBackoffFromJobs(jobs []v1alpha1.JobStatus, configVersion string) time.Duration {
-	// Find last two failed provision jobs with matching ConfigVersion (reverse order)
+func computeBackoffFromFailedJobs(jobs []v1alpha1.JobStatus, match func(*v1alpha1.JobStatus) bool) time.Duration {
 	var last, prev *v1alpha1.JobStatus
 	for i := len(jobs) - 1; i >= 0; i-- {
 		j := &jobs[i]
-		if j.Type != v1alpha1.JobTypeProvision || j.State != v1alpha1.JobStateFailed || j.ConfigVersion != configVersion {
+		if j.State != v1alpha1.JobStateFailed || !match(j) {
 			continue
 		}
 		if last == nil {
@@ -114,4 +113,19 @@ func ComputeBackoffFromJobs(jobs []v1alpha1.JobStatus, configVersion string) tim
 		return BackoffMaxDelay
 	}
 	return nextDelay
+}
+
+// ComputeBackoffFromJobs determines the next backoff duration based on the gap
+// between the last two failed provision jobs with the same ConfigVersion.
+func ComputeBackoffFromJobs(jobs []v1alpha1.JobStatus, configVersion string) time.Duration {
+	return computeBackoffFromFailedJobs(jobs, func(j *v1alpha1.JobStatus) bool {
+		return j.Type == v1alpha1.JobTypeProvision && j.ConfigVersion == configVersion
+	})
+}
+
+// ComputeDeprovisionBackoff determines the next backoff duration for deprovision retries.
+func ComputeDeprovisionBackoff(jobs []v1alpha1.JobStatus) time.Duration {
+	return computeBackoffFromFailedJobs(jobs, func(j *v1alpha1.JobStatus) bool {
+		return j.Type == v1alpha1.JobTypeDeprovision
+	})
 }

--- a/pkg/provisioning/provision_lifecycle.go
+++ b/pkg/provisioning/provision_lifecycle.go
@@ -331,19 +331,34 @@ func updateProvisionJobFromDeprovisionResult(jobs *[]v1alpha1.JobStatus, result 
 	UpdateJob(*jobs, updatedJob)
 }
 
+// RunDeprovisioningLifecycle encapsulates the full deprovisioning flow: trigger if no job
+// exists, poll/retry if one does. Controllers call this instead of duplicating the
+// trigger-or-poll logic. Returns (result, done, error) where done=true means the
+// controller can proceed with finalizer removal.
+func RunDeprovisioningLifecycle(ctx context.Context, provider ProvisioningProvider, resource client.Object,
+	jobs *[]v1alpha1.JobStatus, maxHistory int, pollInterval time.Duration) (ctrl.Result, bool, error) {
+	latestDeprovisionJob := FindLatestJobByType(*jobs, v1alpha1.JobTypeDeprovision)
+
+	if !HasJobID(latestDeprovisionJob) {
+		result, err := TriggerDeprovisionJob(ctx, provider, resource, jobs, maxHistory, pollInterval)
+		return result, false, err
+	}
+
+	return PollDeprovisionJob(ctx, provider, resource, jobs, latestDeprovisionJob, maxHistory, pollInterval)
+}
+
 // PollDeprovisionJob polls the status of an existing deprovision job.
 // Returns (result, done, error) where done=true means the job reached terminal state
 // and the controller can proceed with finalizer removal.
+// When a deprovision job fails with BlockDeletionOnFailure, the function retries
+// after exponential backoff rather than blocking forever.
 func PollDeprovisionJob(ctx context.Context, provider ProvisioningProvider, resource client.Object,
-	jobs *[]v1alpha1.JobStatus, latestDeprovisionJob *v1alpha1.JobStatus, pollInterval time.Duration) (ctrl.Result, bool, error) {
+	jobs *[]v1alpha1.JobStatus, latestDeprovisionJob *v1alpha1.JobStatus, maxHistory int, pollInterval time.Duration) (ctrl.Result, bool, error) {
 	log := ctrllog.FromContext(ctx)
 
 	if latestDeprovisionJob.State.IsTerminal() {
-		// Already terminal — check if deletion should be blocked
 		if !latestDeprovisionJob.State.IsSuccessful() && latestDeprovisionJob.BlockDeletionOnFailure {
-			log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-				"jobID", latestDeprovisionJob.JobID, "state", latestDeprovisionJob.State)
-			return ctrl.Result{RequeueAfter: pollInterval}, false, nil
+			return handleDeprovisionBackoff(ctx, provider, resource, jobs, latestDeprovisionJob, maxHistory, pollInterval)
 		}
 		return ctrl.Result{}, true, nil
 	}
@@ -358,7 +373,6 @@ func PollDeprovisionJob(ctx context.Context, provider ProvisioningProvider, reso
 		return ctrl.Result{RequeueAfter: pollInterval}, false, nil
 	}
 
-	// Update job status if changed
 	if status.State != latestDeprovisionJob.State || status.Message != latestDeprovisionJob.Message {
 		log.Info("deprovision job status changed", "jobID", latestDeprovisionJob.JobID,
 			"oldState", latestDeprovisionJob.State, "newState", status.State)
@@ -368,17 +382,29 @@ func PollDeprovisionJob(ctx context.Context, provider ProvisioningProvider, reso
 		UpdateJob(*jobs, updatedJob)
 	}
 
-	// Continue polling if still running
 	if !status.State.IsTerminal() {
 		return ctrl.Result{RequeueAfter: pollInterval}, false, nil
 	}
 
-	// Job reached terminal state
 	if !status.State.IsSuccessful() && latestDeprovisionJob.BlockDeletionOnFailure {
-		log.Info("deprovision job failed, blocking deletion to prevent orphaned resources",
-			"jobID", latestDeprovisionJob.JobID, "state", status.State)
-		return ctrl.Result{RequeueAfter: pollInterval}, false, nil
+		return handleDeprovisionBackoff(ctx, provider, resource, jobs, latestDeprovisionJob, maxHistory, pollInterval)
 	}
 
 	return ctrl.Result{}, true, nil
+}
+
+func handleDeprovisionBackoff(ctx context.Context, provider ProvisioningProvider, resource client.Object,
+	jobs *[]v1alpha1.JobStatus, latestJob *v1alpha1.JobStatus, maxHistory int, pollInterval time.Duration) (ctrl.Result, bool, error) {
+	log := ctrllog.FromContext(ctx)
+	backoff := ComputeDeprovisionBackoff(*jobs)
+	elapsed := time.Since(latestJob.Timestamp.Time)
+	if elapsed >= backoff {
+		log.Info("deprovision backoff elapsed, retrying", "jobID", latestJob.JobID, "backoff", backoff)
+		result, err := TriggerDeprovisionJob(ctx, provider, resource, jobs, maxHistory, pollInterval)
+		return result, false, err
+	}
+	remaining := backoff - elapsed
+	log.Info("deprovision job failed, retrying after backoff",
+		"jobID", latestJob.JobID, "backoff", backoff, "remaining", remaining)
+	return ctrl.Result{RequeueAfter: remaining}, false, nil
 }

--- a/pkg/provisioning/provision_lifecycle_test.go
+++ b/pkg/provisioning/provision_lifecycle_test.go
@@ -596,23 +596,48 @@ var _ = ginkgo.Describe("PollDeprovisionJob", func() {
 		}
 		latestJob := &jobs[0]
 		provider := &mockProvider{}
-		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, pollInterval)
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(done).To(BeTrue())
 		Expect(result).To(Equal(ctrl.Result{}))
 	})
 
-	ginkgo.It("blocks deletion when already-terminal job failed with BlockDeletionOnFailure", func() {
+	ginkgo.It("waits for backoff when already-terminal job failed with BlockDeletionOnFailure", func() {
 		jobs := []v1alpha1.JobStatus{
 			{JobID: "d1", Type: v1alpha1.JobTypeDeprovision, State: v1alpha1.JobStateFailed,
 				BlockDeletionOnFailure: true, Timestamp: metav1.NewTime(time.Now())},
 		}
 		latestJob := &jobs[0]
 		provider := &mockProvider{}
-		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, pollInterval)
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(done).To(BeFalse())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+	})
+
+	ginkgo.It("retries deprovision after backoff when failed with BlockDeletionOnFailure", func() {
+		jobs := []v1alpha1.JobStatus{
+			{JobID: "d1", Type: v1alpha1.JobTypeDeprovision, State: v1alpha1.JobStateFailed,
+				BlockDeletionOnFailure: true, Timestamp: metav1.NewTime(time.Now().Add(-BackoffBaseDelay - time.Second))},
+		}
+		latestJob := &jobs[0]
+		retryCalled := false
+		provider := &mockProvider{
+			triggerDeprovisionFunc: func(_ context.Context, _ client.Object) (*DeprovisionResult, error) {
+				retryCalled = true
+				return &DeprovisionResult{
+					Action: DeprovisionTriggered,
+					JobID:  "d2",
+				}, nil
+			},
+		}
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+		Expect(retryCalled).To(BeTrue())
 		Expect(result.RequeueAfter).To(Equal(pollInterval))
+		retryJob := FindLatestJobByType(jobs, v1alpha1.JobTypeDeprovision)
+		Expect(retryJob.JobID).To(Equal("d2"))
 	})
 
 	ginkgo.It("continues polling when job is still running", func() {
@@ -625,7 +650,7 @@ var _ = ginkgo.Describe("PollDeprovisionJob", func() {
 				return ProvisionStatus{State: v1alpha1.JobStateRunning, Message: "in progress"}, nil
 			},
 		}
-		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, pollInterval)
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(done).To(BeFalse())
 		Expect(result.RequeueAfter).To(Equal(pollInterval))
@@ -644,13 +669,13 @@ var _ = ginkgo.Describe("PollDeprovisionJob", func() {
 				return ProvisionStatus{State: v1alpha1.JobStateSucceeded, Message: "done"}, nil
 			},
 		}
-		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, pollInterval)
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(done).To(BeTrue())
 		Expect(result).To(Equal(ctrl.Result{}))
 	})
 
-	ginkgo.It("blocks deletion when poll shows failure with BlockDeletionOnFailure", func() {
+	ginkgo.It("waits for backoff when poll shows failure with BlockDeletionOnFailure", func() {
 		jobs := []v1alpha1.JobStatus{
 			{JobID: "d1", Type: v1alpha1.JobTypeDeprovision, State: v1alpha1.JobStateRunning,
 				BlockDeletionOnFailure: true, Timestamp: metav1.NewTime(time.Now())},
@@ -661,10 +686,11 @@ var _ = ginkgo.Describe("PollDeprovisionJob", func() {
 				return ProvisionStatus{State: v1alpha1.JobStateFailed, Message: "deprovision failed"}, nil
 			},
 		}
-		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, pollInterval)
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(done).To(BeFalse())
-		Expect(result.RequeueAfter).To(Equal(pollInterval))
+		Expect(result.RequeueAfter).To(BeNumerically("<=", BackoffBaseDelay))
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 	})
 
 	ginkgo.It("persists error message on poll failure and requeues", func() {
@@ -677,7 +703,7 @@ var _ = ginkgo.Describe("PollDeprovisionJob", func() {
 				return ProvisionStatus{}, fmt.Errorf("timeout")
 			},
 		}
-		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, pollInterval)
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(done).To(BeFalse())
 		Expect(result.RequeueAfter).To(Equal(pollInterval))
@@ -695,7 +721,7 @@ var _ = ginkgo.Describe("PollDeprovisionJob", func() {
 				return ProvisionStatus{State: v1alpha1.JobStateFailed, Message: "failed"}, nil
 			},
 		}
-		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, pollInterval)
+		result, done, err := PollDeprovisionJob(ctx, provider, resource, &jobs, latestJob, 10, pollInterval)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(done).To(BeTrue())
 		Expect(result).To(Equal(ctrl.Result{}))


### PR DESCRIPTION
## Summary
- Add retry with exponential backoff for failed deprovision jobs that have `BlockDeletionOnFailure=true`
- Refactor 7 controllers to use shared `RunDeprovisioningLifecycle`, eliminating ~500 lines of duplicated inline logic

## Problem
When a deprovision job fails (e.g., due to a transient AAP controller-task pod rollout), the operator blocks deletion to prevent orphaned resources — but never retries. The resource is stuck in `Deleting` phase permanently with no recovery path.

`BlockDeletionOnFailure` was added in PR #110 as a safety measure. The retry mechanism was implemented for provision (`HandleBackoff` + `ComputeBackoffFromJobs`) but never extended to deprovision.

## Changes
- **`PollDeprovisionJob`**: When a failed deprovision job's backoff elapses, retry via `TriggerDeprovisionJob`. Deletion stays blocked until a retry succeeds — no orphan risk.
- **`RunDeprovisioningLifecycle`**: New shared entry point (trigger-or-poll), matching `RunProvisioningLifecycle`.
- **`ComputeDeprovisionBackoff`**: Reuses extracted `computeBackoffFromFailedJobs` helper.
- **7 controllers**: PublicIP, PublicIPPool, Subnet, SecurityGroup, VirtualNetwork, PublicIPAttachment, ClusterOrder — replaced inline logic with `RunDeprovisioningLifecycle`.
- **ComputeInstance**: Not refactored (EDA-specific logic).

## Test plan
- [x] 106/106 provisioning unit tests pass (2 new: backoff waiting + retry after backoff)
- [x] `go build ./...` clean
- [ ] Controller integration tests (envtest) — CI

Jira: [OSAC-1281](https://redhat.atlassian.net/browse/OSAC-1281)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deprovisioning retry behavior with exponential backoff strategy instead of fixed polling intervals
  * Enhanced consistency in handling failed deprovisioning scenarios across resource types

* **Refactor**
  * Consolidated deprovisioning job lifecycle management into a shared, centralized component
  * Streamlined deprovisioning logic across multiple controllers for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->