### PR TITLE
fix: use correct manager binary path in Helm deployment

### DIFF
--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: manager
         command:
-        - /manager
+        - /usr/local/bin/manager
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081


### PR DESCRIPTION
The Helm chart deployment template specified /manager as the container command, but the operator image installs the binary at /usr/local/bin/manager. This mismatch caused operator pods to fail with CreateContainerError when deployed via Helm (e.g. through osac-installer), while the kustomize-based deployment in config/manager/manager.yaml already used the correct path.

Align the Helm template with the kustomize manifest and container image layout so Helm deployments start successfully.

Assisted-by: Cursor <noreply@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the manager container initialization configuration in the Helm deployment template to use the correct binary path for startup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->