### PR TITLE
OSAC-1357: Fix Helm chart manager binary path

### DIFF
--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: manager
         command:
-        - /manager
+        - /usr/local/bin/manager
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081


### PR DESCRIPTION
## Summary
- The Containerfile copies the manager binary to `/usr/local/bin/manager` and sets `ENTRYPOINT ["/usr/local/bin/manager"]`, but the Helm chart deployment template still had `command: ["/manager"]`
- This causes `CreateContainerError` on any Helm deployment using the latest operator image
- Aligns the Helm chart with `config/manager/manager.yaml` which already has the correct path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the manager container deployment configuration path to ensure proper executable resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->