### PR TITLE
OSAC-721: add guestOSFamily field to ComputeInstance CRD

### DIFF
--- a/api/v1alpha1/computeinstance_types.go
+++ b/api/v1alpha1/computeinstance_types.go
@@ -100,6 +100,14 @@ type ComputeInstanceSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="image is immutable"
 	Image ImageSpec `json:"image"`
 
+	// GuestOSFamily specifies the guest operating system family for the VM.
+	// To support future OS families, this field is a freeform string.
+	// Currently, any value other than "windows" will be treated as "linux".
+	// This field is immutable after creation.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="guestOSFamily is immutable"
+	GuestOSFamily string `json:"guestOSFamily,omitempty"`
+
 	// Cores is the number of CPU cores
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
@@ -305,6 +313,7 @@ type ComputeInstanceStatus struct {
 // +kubebuilder:printcolumn:name="Template",type=string,JSONPath=`.spec.templateID`
 // +kubebuilder:printcolumn:name="Cores",type=integer,JSONPath=`.spec.cores`
 // +kubebuilder:printcolumn:name="Memory",type=integer,JSONPath=`.spec.memoryGiB`
+// +kubebuilder:printcolumn:name="OS",type=string,JSONPath=`.spec.guestOSFamily`
 // +kubebuilder:printcolumn:name="RunStrategy",type=string,JSONPath=`.spec.runStrategy`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="IP",type=string,JSONPath=`.status.ipAddress`

--- a/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
@@ -28,6 +28,9 @@ spec:
     - jsonPath: .spec.memoryGiB
       name: Memory
       type: integer
+    - jsonPath: .spec.guestOSFamily
+      name: OS
+      type: string
     - jsonPath: .spec.runStrategy
       name: RunStrategy
       type: string
@@ -105,6 +108,16 @@ spec:
                 type: integer
                 x-kubernetes-validations:
                 - message: cores is immutable
+                  rule: self == oldSelf
+              guestOSFamily:
+                description: |-
+                  GuestOSFamily specifies the guest operating system family for the VM.
+                  To support future OS families, this field is a freeform string.
+                  Currently, any value other than "windows" will be treated as "linux".
+                  This field is immutable after creation.
+                type: string
+                x-kubernetes-validations:
+                - message: guestOSFamily is immutable
                   rule: self == oldSelf
               image:
                 description: Image defines the VM image configuration

--- a/config/crd/bases/osac.openshift.io_computeinstances.yaml
+++ b/config/crd/bases/osac.openshift.io_computeinstances.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.memoryGiB
       name: Memory
       type: integer
+    - jsonPath: .spec.guestOSFamily
+      name: OS
+      type: string
     - jsonPath: .spec.runStrategy
       name: RunStrategy
       type: string
@@ -103,6 +106,16 @@ spec:
                 type: integer
                 x-kubernetes-validations:
                 - message: cores is immutable
+                  rule: self == oldSelf
+              guestOSFamily:
+                description: |-
+                  GuestOSFamily specifies the guest operating system family for the VM.
+                  To support future OS families, this field is a freeform string.
+                  Currently, any value other than "windows" will be treated as "linux".
+                  This field is immutable after creation.
+                type: string
+                x-kubernetes-validations:
+                - message: guestOSFamily is immutable
                   rule: self == oldSelf
               image:
                 description: Image defines the VM image configuration

--- a/internal/controller/computeinstance_validation_test.go
+++ b/internal/controller/computeinstance_validation_test.go
@@ -399,6 +399,95 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 		})
 	})
 
+	Describe("GuestOSFamily validation", func() {
+		It("should allow creation without guestOSFamily field (optional)", func() {
+			instance := createValidInstance("test-no-guestos")
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		})
+
+		It("should allow creation with guestOSFamily set to linux", func() {
+			instance := createValidInstance("test-linux")
+			instance.Spec.GuestOSFamily = "linux"
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		})
+
+		It("should allow creation with guestOSFamily set to windows", func() {
+			instance := createValidInstance("test-windows")
+			instance.Spec.GuestOSFamily = "windows"
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		})
+
+		It("should allow creation with unknown guestOSFamily value (freeform string)", func() {
+			instance := createValidInstance("test-freebsd")
+			instance.Spec.GuestOSFamily = "freebsd"
+			// No validation constraint, freeform string per D-03
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		})
+
+		It("should reject changing guestOSFamily after creation", func() {
+			instance := createValidInstance("test-immutable")
+			instance.Spec.GuestOSFamily = "linux"
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			// Fetch latest version
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+
+			// Attempt to change guestOSFamily
+			instance.Spec.GuestOSFamily = "windows"
+			err := k8sClient.Update(ctx, instance)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("guestOSFamily is immutable"))
+		})
+
+		It("should allow updates when guestOSFamily unchanged", func() {
+			instance := createValidInstance("test-mutable-other")
+			instance.Spec.GuestOSFamily = "windows"
+			instance.Spec.RunStrategy = osacv1alpha1.RunStrategyAlways
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			// Fetch latest version
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+
+			// Change mutable field (runStrategy), leave guestOSFamily unchanged
+			instance.Spec.RunStrategy = osacv1alpha1.RunStrategyHalted
+			Expect(k8sClient.Update(ctx, instance)).To(Succeed())
+		})
+
+		It("should allow updates when guestOSFamily was not set and remains unset", func() {
+			instance := createValidInstance("test-unset-unchanged")
+			instance.Spec.RunStrategy = osacv1alpha1.RunStrategyAlways
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			// Fetch latest version
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+
+			// Change mutable field, leave guestOSFamily unset
+			instance.Spec.RunStrategy = osacv1alpha1.RunStrategyHalted
+			Expect(k8sClient.Update(ctx, instance)).To(Succeed())
+		})
+
+		It("should serialize guestOSFamily to JSON when set", func() {
+			instance := createValidInstance("test-serialize")
+			instance.Spec.GuestOSFamily = "windows"
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			// Fetch and verify
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+			Expect(instance.Spec.GuestOSFamily).To(Equal("windows"))
+		})
+
+		It("should omit guestOSFamily from JSON when empty (omitempty)", func() {
+			instance := createValidInstance("test-omitempty")
+			// Don't set GuestOSFamily
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			// Fetch and verify field is empty
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+			Expect(instance.Spec.GuestOSFamily).To(Equal(""))
+		})
+	})
+
 	Describe("MaxItems validation", func() {
 		It("should reject creating ComputeInstance with more than 8 networkAttachments", func() {
 			instance := createValidInstance("test-max-attachments")


### PR DESCRIPTION
- Add GuestOSFamily string field to ComputeInstanceSpec after Image field
- Field is optional (omitempty) with no default value
- Immutable after creation via CEL validation (self == oldSelf)
- Freeform string (no enum, no pattern) for future OS expansion
- Add OS printcolumn between Memory and RunStrategy
- Regenerate CRD manifests and DeepCopy methods
- Sync Helm CRD templates
- Add 9 validation tests covering:
  - Optional field handling (4 cases): creation without field, linux, windows, freeform string
  - Immutability (3 cases): reject changes, allow updates when unchanged, allow updates when unset
  - Serialization (2 cases): round-trip when set, omitempty when empty
- All existing tests pass (no regressions)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `guestOSFamily` field to ComputeInstance resources, allowing users to specify the guest operating system type (Windows or Linux)
  * Guest OS family is immutable after creation and displayed in resource listings as an OS column

* **Tests**
  * Added validation tests for guest OS family field behavior and immutability constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->