### PR TITLE
OSAC-1398: Fix Helm chart ClusterRole missing publicipattachments and services

### DIFF
--- a/charts/operator/templates/clusterrole.yaml
+++ b/charts/operator/templates/clusterrole.yaml
@@ -19,6 +19,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+- apiGroups:
   - events.k8s.io
   resources:
   - events
@@ -61,6 +67,7 @@ rules:
   resources:
   - clusterorders
   - computeinstances
+  - publicipattachments
   - publicippools
   - publicips
   - securitygroups
@@ -80,6 +87,7 @@ rules:
   resources:
   - clusterorders/finalizers
   - computeinstances/finalizers
+  - publicipattachments/finalizers
   - publicippools/finalizers
   - publicips/finalizers
   - securitygroups/finalizers
@@ -93,6 +101,7 @@ rules:
   resources:
   - clusterorders/status
   - computeinstances/status
+  - publicipattachments/status
   - publicippools/status
   - publicips/status
   - securitygroups/status


### PR DESCRIPTION
## Summary
- Adds `publicipattachments` to all three `osac.openshift.io` RBAC rule blocks (resources, finalizers, status)
- Adds `services` get permission (missing from Helm chart but present in kustomize `config/rbac/role.yaml`)
- Syncs the Helm chart ClusterRole with the kubebuilder-generated kustomize RBAC

Without this fix, the operator crashes with:
```
publicipattachments.osac.openshift.io is forbidden: User "system:serviceaccount:osac:osac-operator"
cannot list resource "publicipattachments" in API group "osac.openshift.io" at the cluster scope
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator permissions to enable management of public IP attachments and enhanced service access capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->