### PR TITLE
NO-ISSUE: Ignore Helm chart templates in yamllint

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,4 +1,6 @@
 extends: default
+ignore:
+  - charts/*/templates/
 rules:
   line-length: disable
   document-start: disable


### PR DESCRIPTION
Helm templates under charts/*/templates/ use Go template syntax that yamllint cannot parse, so exclude them from linting.