### PR TITLE
OSAC-338: make NetworkClass optional on VirtualNetwork CRD

### DIFF
--- a/api/v1alpha1/virtualnetwork_types.go
+++ b/api/v1alpha1/virtualnetwork_types.go
@@ -37,10 +37,11 @@ type VirtualNetworkSpec struct {
 	// +kubebuilder:validation:Type=string
 	IPv6CIDR string `json:"ipv6Cidr,omitempty"`
 
-	// NetworkClass is the name of the NetworkClass that defines implementation strategy
-	// +kubebuilder:validation:Required
+	// NetworkClass is the name of the NetworkClass that defines implementation strategy.
+	// When omitted, the platform default NetworkClass is used.
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
-	NetworkClass string `json:"networkClass"`
+	NetworkClass string `json:"networkClass,omitempty"`
 
 	// ImplementationStrategy determines the underlying network backend and Ansible role to use.
 	// This value is derived from the NetworkClass at creation time and stored here for direct

--- a/charts/operator-crds/templates/osac.openshift.io_virtualnetworks.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_virtualnetworks.yaml
@@ -66,15 +66,15 @@ spec:
                 description: IPv6CIDR is the IPv6 CIDR block for this virtual network
                 type: string
               networkClass:
-                description: NetworkClass is the name of the NetworkClass that defines
-                  implementation strategy
+                description: |-
+                  NetworkClass is the name of the NetworkClass that defines implementation strategy.
+                  When omitted, the platform default NetworkClass is used.
                 type: string
               region:
                 description: Region is the cloud region where this VirtualNetwork
                   will be provisioned
                 type: string
             required:
-            - networkClass
             - region
             type: object
           status:

--- a/config/crd/bases/osac.openshift.io_virtualnetworks.yaml
+++ b/config/crd/bases/osac.openshift.io_virtualnetworks.yaml
@@ -64,15 +64,15 @@ spec:
                 description: IPv6CIDR is the IPv6 CIDR block for this virtual network
                 type: string
               networkClass:
-                description: NetworkClass is the name of the NetworkClass that defines
-                  implementation strategy
+                description: |-
+                  NetworkClass is the name of the NetworkClass that defines implementation strategy.
+                  When omitted, the platform default NetworkClass is used.
                 type: string
               region:
                 description: Region is the cloud region where this VirtualNetwork
                   will be provisioned
                 type: string
             required:
-            - networkClass
             - region
             type: object
           status:


### PR DESCRIPTION
## Summary

- Changes `NetworkClass` field on `VirtualNetworkSpec` from `+kubebuilder:validation:Required` to `+kubebuilder:validation:Optional` with `omitempty`
- Regenerates CRD manifests to remove `networkClass` from the `required` list
- Enables VirtualNetwork creation without specifying a NetworkClass, falling back to the platform default (the `is_default` field on NetworkClass, implemented in fulfillment-service via [MGMT-23740](https://redhat.atlassian.net/browse/MGMT-23740))

## Test plan

- [x] `make build` passes (includes `go vet`, `go fmt`, unit tests)
- [x] CRD YAML no longer lists `networkClass` in `required`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * `NetworkClass` field in VirtualNetwork resources is now optional and can be omitted from API payloads. Default behavior is applied when the field is not specified.

* **Documentation**
  * Enhanced `NetworkClass` field documentation with clarification on omission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->