### PR TITLE
NO-ISSUE: Add Helm build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ go.work
 
 # Development memory/notes (local only)
 MEMORY.md
+
+# Helm dependency build artifacts
+charts/*/charts/
+charts/*/Chart.lock


### PR DESCRIPTION
## Summary
- Add `charts/*/charts/` and `charts/*/Chart.lock` to `.gitignore`
- These are generated by `helm dependency build` and should not be tracked