### PR TITLE
OSAC-362: Add CEL immutability rules to networking CRD types

### DIFF
--- a/api/v1alpha1/publicippool_types.go
+++ b/api/v1alpha1/publicippool_types.go
@@ -25,12 +25,14 @@ type PublicIPPoolSpec struct {
 	// CIDRs is the list of CIDR blocks for this pool. All CIDRs must match the declared IPFamily.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="cidrs is immutable"
 	CIDRs []string `json:"cidrs"`
 
 	// IPFamily indicates the IP address family for this pool (IPv4 or IPv6)
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Enum=IPv4;IPv6
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipFamily is immutable"
 	IPFamily string `json:"ipFamily"`
 
 	// ImplementationStrategy determines the backend used to advertise IPs (e.g., metallb-l2).
@@ -38,6 +40,7 @@ type PublicIPPoolSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Enum=metallb-l2;netris
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="implementationStrategy is immutable"
 	ImplementationStrategy string `json:"implementationStrategy,omitempty"`
 }
 

--- a/api/v1alpha1/securitygroup_types.go
+++ b/api/v1alpha1/securitygroup_types.go
@@ -74,12 +74,14 @@ type SecurityGroupSpec struct {
 	// VirtualNetwork is the ID of the parent VirtualNetwork
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="virtualNetwork is immutable"
 	VirtualNetwork string `json:"virtualNetwork"`
 
 	// ImplementationStrategy determines the backend used to enforce security rules.
 	// Set by the fulfillment-service; defaults to network_policy when empty.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="implementationStrategy is immutable"
 	ImplementationStrategy string `json:"implementationStrategy,omitempty"`
 
 	// IngressRules defines the ingress security rules

--- a/api/v1alpha1/subnet_types.go
+++ b/api/v1alpha1/subnet_types.go
@@ -25,16 +25,19 @@ type SubnetSpec struct {
 	// VirtualNetwork is the ID of the parent VirtualNetwork
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="virtualNetwork is immutable"
 	VirtualNetwork string `json:"virtualNetwork"`
 
 	// IPv4CIDR is the IPv4 CIDR block for this subnet
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipv4Cidr is immutable"
 	IPv4CIDR string `json:"ipv4Cidr,omitempty"`
 
 	// IPv6CIDR is the IPv6 CIDR block for this subnet
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipv6Cidr is immutable"
 	IPv6CIDR string `json:"ipv6Cidr,omitempty"`
 }
 

--- a/api/v1alpha1/virtualnetwork_types.go
+++ b/api/v1alpha1/virtualnetwork_types.go
@@ -25,22 +25,26 @@ type VirtualNetworkSpec struct {
 	// Region is the cloud region where this VirtualNetwork will be provisioned
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="region is immutable"
 	Region string `json:"region"`
 
 	// IPv4CIDR is the IPv4 CIDR block for this virtual network
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipv4Cidr is immutable"
 	IPv4CIDR string `json:"ipv4Cidr,omitempty"`
 
 	// IPv6CIDR is the IPv6 CIDR block for this virtual network
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipv6Cidr is immutable"
 	IPv6CIDR string `json:"ipv6Cidr,omitempty"`
 
 	// NetworkClass is the name of the NetworkClass that defines implementation strategy.
 	// When omitted, the platform default NetworkClass is used.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="networkClass is immutable"
 	NetworkClass string `json:"networkClass,omitempty"`
 
 	// ImplementationStrategy determines the underlying network backend and Ansible role to use.
@@ -48,6 +52,7 @@ type VirtualNetworkSpec struct {
 	// access by controllers and provisioning systems.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="implementationStrategy is immutable"
 	ImplementationStrategy string `json:"implementationStrategy,omitempty"`
 }
 

--- a/charts/operator-crds/templates/osac.openshift.io_publicippools.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_publicippools.yaml
@@ -66,6 +66,9 @@ spec:
                   type: string
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: cidrs is immutable
+                  rule: self == oldSelf
               implementationStrategy:
                 description: |-
                   ImplementationStrategy determines the backend used to advertise IPs (e.g., metallb-l2).
@@ -74,6 +77,9 @@ spec:
                 - metallb-l2
                 - netris
                 type: string
+                x-kubernetes-validations:
+                - message: implementationStrategy is immutable
+                  rule: self == oldSelf
               ipFamily:
                 description: IPFamily indicates the IP address family for this pool
                   (IPv4 or IPv6)
@@ -81,6 +87,9 @@ spec:
                 - IPv4
                 - IPv6
                 type: string
+                x-kubernetes-validations:
+                - message: ipFamily is immutable
+                  rule: self == oldSelf
             required:
             - cidrs
             - ipFamily

--- a/charts/operator-crds/templates/osac.openshift.io_securitygroups.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_securitygroups.yaml
@@ -102,6 +102,9 @@ spec:
                   ImplementationStrategy determines the backend used to enforce security rules.
                   Set by the fulfillment-service; defaults to network_policy when empty.
                 type: string
+                x-kubernetes-validations:
+                - message: implementationStrategy is immutable
+                  rule: self == oldSelf
               ingressRules:
                 description: IngressRules defines the ingress security rules
                 items:
@@ -149,6 +152,9 @@ spec:
               virtualNetwork:
                 description: VirtualNetwork is the ID of the parent VirtualNetwork
                 type: string
+                x-kubernetes-validations:
+                - message: virtualNetwork is immutable
+                  rule: self == oldSelf
             required:
             - virtualNetwork
             type: object

--- a/charts/operator-crds/templates/osac.openshift.io_subnets.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_subnets.yaml
@@ -59,12 +59,21 @@ spec:
               ipv4Cidr:
                 description: IPv4CIDR is the IPv4 CIDR block for this subnet
                 type: string
+                x-kubernetes-validations:
+                - message: ipv4Cidr is immutable
+                  rule: self == oldSelf
               ipv6Cidr:
                 description: IPv6CIDR is the IPv6 CIDR block for this subnet
                 type: string
+                x-kubernetes-validations:
+                - message: ipv6Cidr is immutable
+                  rule: self == oldSelf
               virtualNetwork:
                 description: VirtualNetwork is the ID of the parent VirtualNetwork
                 type: string
+                x-kubernetes-validations:
+                - message: virtualNetwork is immutable
+                  rule: self == oldSelf
             required:
             - virtualNetwork
             type: object

--- a/charts/operator-crds/templates/osac.openshift.io_virtualnetworks.yaml
+++ b/charts/operator-crds/templates/osac.openshift.io_virtualnetworks.yaml
@@ -59,21 +59,36 @@ spec:
                   This value is derived from the NetworkClass at creation time and stored here for direct
                   access by controllers and provisioning systems.
                 type: string
+                x-kubernetes-validations:
+                - message: implementationStrategy is immutable
+                  rule: self == oldSelf
               ipv4Cidr:
                 description: IPv4CIDR is the IPv4 CIDR block for this virtual network
                 type: string
+                x-kubernetes-validations:
+                - message: ipv4Cidr is immutable
+                  rule: self == oldSelf
               ipv6Cidr:
                 description: IPv6CIDR is the IPv6 CIDR block for this virtual network
                 type: string
+                x-kubernetes-validations:
+                - message: ipv6Cidr is immutable
+                  rule: self == oldSelf
               networkClass:
                 description: |-
                   NetworkClass is the name of the NetworkClass that defines implementation strategy.
                   When omitted, the platform default NetworkClass is used.
                 type: string
+                x-kubernetes-validations:
+                - message: networkClass is immutable
+                  rule: self == oldSelf
               region:
                 description: Region is the cloud region where this VirtualNetwork
                   will be provisioned
                 type: string
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: self == oldSelf
             required:
             - region
             type: object

--- a/config/crd/bases/osac.openshift.io_publicippools.yaml
+++ b/config/crd/bases/osac.openshift.io_publicippools.yaml
@@ -64,6 +64,9 @@ spec:
                   type: string
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: cidrs is immutable
+                  rule: self == oldSelf
               implementationStrategy:
                 description: |-
                   ImplementationStrategy determines the backend used to advertise IPs (e.g., metallb-l2).
@@ -72,6 +75,9 @@ spec:
                 - metallb-l2
                 - netris
                 type: string
+                x-kubernetes-validations:
+                - message: implementationStrategy is immutable
+                  rule: self == oldSelf
               ipFamily:
                 description: IPFamily indicates the IP address family for this pool
                   (IPv4 or IPv6)
@@ -79,6 +85,9 @@ spec:
                 - IPv4
                 - IPv6
                 type: string
+                x-kubernetes-validations:
+                - message: ipFamily is immutable
+                  rule: self == oldSelf
             required:
             - cidrs
             - ipFamily

--- a/config/crd/bases/osac.openshift.io_securitygroups.yaml
+++ b/config/crd/bases/osac.openshift.io_securitygroups.yaml
@@ -100,6 +100,9 @@ spec:
                   ImplementationStrategy determines the backend used to enforce security rules.
                   Set by the fulfillment-service; defaults to network_policy when empty.
                 type: string
+                x-kubernetes-validations:
+                - message: implementationStrategy is immutable
+                  rule: self == oldSelf
               ingressRules:
                 description: IngressRules defines the ingress security rules
                 items:
@@ -147,6 +150,9 @@ spec:
               virtualNetwork:
                 description: VirtualNetwork is the ID of the parent VirtualNetwork
                 type: string
+                x-kubernetes-validations:
+                - message: virtualNetwork is immutable
+                  rule: self == oldSelf
             required:
             - virtualNetwork
             type: object

--- a/config/crd/bases/osac.openshift.io_subnets.yaml
+++ b/config/crd/bases/osac.openshift.io_subnets.yaml
@@ -57,12 +57,21 @@ spec:
               ipv4Cidr:
                 description: IPv4CIDR is the IPv4 CIDR block for this subnet
                 type: string
+                x-kubernetes-validations:
+                - message: ipv4Cidr is immutable
+                  rule: self == oldSelf
               ipv6Cidr:
                 description: IPv6CIDR is the IPv6 CIDR block for this subnet
                 type: string
+                x-kubernetes-validations:
+                - message: ipv6Cidr is immutable
+                  rule: self == oldSelf
               virtualNetwork:
                 description: VirtualNetwork is the ID of the parent VirtualNetwork
                 type: string
+                x-kubernetes-validations:
+                - message: virtualNetwork is immutable
+                  rule: self == oldSelf
             required:
             - virtualNetwork
             type: object

--- a/config/crd/bases/osac.openshift.io_virtualnetworks.yaml
+++ b/config/crd/bases/osac.openshift.io_virtualnetworks.yaml
@@ -57,21 +57,36 @@ spec:
                   This value is derived from the NetworkClass at creation time and stored here for direct
                   access by controllers and provisioning systems.
                 type: string
+                x-kubernetes-validations:
+                - message: implementationStrategy is immutable
+                  rule: self == oldSelf
               ipv4Cidr:
                 description: IPv4CIDR is the IPv4 CIDR block for this virtual network
                 type: string
+                x-kubernetes-validations:
+                - message: ipv4Cidr is immutable
+                  rule: self == oldSelf
               ipv6Cidr:
                 description: IPv6CIDR is the IPv6 CIDR block for this virtual network
                 type: string
+                x-kubernetes-validations:
+                - message: ipv6Cidr is immutable
+                  rule: self == oldSelf
               networkClass:
                 description: |-
                   NetworkClass is the name of the NetworkClass that defines implementation strategy.
                   When omitted, the platform default NetworkClass is used.
                 type: string
+                x-kubernetes-validations:
+                - message: networkClass is immutable
+                  rule: self == oldSelf
               region:
                 description: Region is the cloud region where this VirtualNetwork
                   will be provisioned
                 type: string
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: self == oldSelf
             required:
             - region
             type: object


### PR DESCRIPTION
## Summary

- Add CEL `XValidation` immutability rules (`self == oldSelf`) to all networking CRD spec fields that should never change after creation
- Covers VirtualNetwork (region, ipv4Cidr, ipv6Cidr, networkClass, implementationStrategy), Subnet (virtualNetwork, ipv4Cidr, ipv6Cidr), SecurityGroup (virtualNetwork, implementationStrategy), and PublicIPPool (cidrs, ipFamily, implementationStrategy)
- Defense-in-depth against direct `kubectl patch`/`kubectl edit` bypassing the fulfillment-service API

## Changes

1. VirtualNetwork `ipv4Cidr` -> patched (accepted change to 10.0.0.0/16)
2. VirtualNetwork `region` -> patched
3. VirtualNetwork `networkClass` -> patched
4. Subnet `ipv4Cidr` -> patched

ComputeInstance, PublicIP, and PublicIPAttachment already had CEL immutability rules, but the core networking resources (VirtualNetwork, Subnet, SecurityGroup, PublicIPPool) did not. This closes that gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Validation Updates**
  * Immutability constraints now enforced on specific resource fields. PublicIPPool, SecurityGroup, Subnet, and VirtualNetwork resources prevent modification of designated specification fields after creation, ensuring data consistency and preventing accidental updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->