### PR TITLE
OSAC-496: Remove subnet/tenant fallback dead code

### DIFF
--- a/internal/controller/computeinstance_controller.go
+++ b/internal/controller/computeinstance_controller.go
@@ -60,6 +60,10 @@ const (
 // instead of exponential backoff.
 var errSubnetNotFound = errors.New("subnet CR not found")
 
+// errSubnetRequired is returned when networkAttachments[0].subnetRef is empty.
+// Permanent configuration error — handleUpdate does not requeue.
+var errSubnetRequired = errors.New("primary subnet reference is required")
+
 // ComputeInstanceReconciler reconciles a ComputeInstance object
 type ComputeInstanceReconciler struct {
 	client.Client
@@ -594,15 +598,13 @@ func (r *ComputeInstanceReconciler) handleDeprovisioning(ctx context.Context, in
 // resolveSubnetTargetNamespace looks up the Subnet CR referenced by the primary subnet
 // (networkAttachments[0].subnetRef) and returns the subnet target
 // namespace (which equals the Subnet CR name).
-// Returns empty string if no primary subnet is set.
-// Returns error if Subnet CR lookup fails.
+// Returns error if the primary subnet reference is empty or Subnet CR lookup fails.
 func (r *ComputeInstanceReconciler) resolveSubnetTargetNamespace(ctx context.Context, instance *v1alpha1.ComputeInstance) (string, error) {
 	log := ctrllog.FromContext(ctx)
 
 	primarySubnetRef := instance.Spec.PrimarySubnetRef()
 	if primarySubnetRef == "" {
-		// No subnet reference, no namespace to resolve
-		return "", nil
+		return "", errSubnetRequired
 	}
 
 	// Look up Subnet CR in the same namespace as ComputeInstance
@@ -629,15 +631,11 @@ func (r *ComputeInstanceReconciler) resolveSubnetTargetNamespace(ctx context.Con
 }
 
 // syncSubnetTargetNamespaceAnnotation ensures the subnet-target-namespace annotation is set
-// when a primary subnet (networkAttachments[0].subnetRef) is configured.
+// from the primary subnet (networkAttachments[0].subnetRef).
 // The primary subnet reference is immutable, so the annotation only needs to be resolved
 // and written once; subsequent reconciles reuse the cached annotation value.
 // Returns the resolved namespace, whether the annotation was written, and any error.
 func (r *ComputeInstanceReconciler) syncSubnetTargetNamespaceAnnotation(ctx context.Context, instance *v1alpha1.ComputeInstance) (string, bool, error) {
-	if instance.Spec.PrimarySubnetRef() == "" {
-		return "", false, nil
-	}
-
 	// Primary subnet is immutable — if the annotation is already set, reuse it.
 	if ns, ok := instance.Annotations[osacSubnetTargetNamespaceAnnotation]; ok {
 		return ns, false, nil
@@ -739,13 +737,9 @@ func (r *ComputeInstanceReconciler) handleUpdate(ctx context.Context, _ reconcil
 		return ctrl.Result{}, err
 	}
 
-	// When a networkAttachment is set, the VM is created in the subnet target namespace
-	// (by the AAP playbook), not in the tenant target namespace.  Reuse the
-	// value resolved by syncMetadataPreflight to avoid a redundant API call.
-	targetNamespace := tenant.Status.Namespace
-	if subnetTargetNamespace != "" {
-		targetNamespace = subnetTargetNamespace
-	}
+	// The VM is created in the subnet target namespace (by the AAP playbook).
+	// Reuse the value resolved by syncMetadataPreflight to avoid a redundant API call.
+	targetNamespace := subnetTargetNamespace
 
 	kv, err := r.findKubeVirtVMs(ctx, targetClient, instance, targetNamespace)
 	if err != nil {

--- a/internal/controller/computeinstance_controller_test.go
+++ b/internal/controller/computeinstance_controller_test.go
@@ -59,6 +59,7 @@ func createReadyTenant(ctx context.Context, namespace, name string) {
 	tenant.Status.Phase = osacv1alpha1.TenantPhaseReady
 	tenant.Status.Namespace = namespace
 	Expect(k8sClient.Status().Update(ctx, tenant)).To(Succeed())
+	ensureTestSubnet(ctx, namespace)
 }
 
 // deleteTenantInNamespace removes a Tenant by name in the given namespace (clears finalizers first).
@@ -87,6 +88,8 @@ var _ = Describe("ComputeInstance Controller", func() {
 		computeInstance := &osacv1alpha1.ComputeInstance{}
 
 		BeforeEach(func() {
+			ensureTestSubnet(ctx, namespaceName)
+
 			By("creating a tenant for the ComputeInstance to reference")
 			tenant := &osacv1alpha1.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1993,17 +1996,19 @@ var _ = Describe("ComputeInstance Controller", func() {
 			reconciler = NewComputeInstanceReconciler(testMcManager, "", namespaceName, "", &mockProvisioningProvider{}, 0, 0, mcmanager.LocalCluster)
 		})
 
-		It("should return empty string when subnetRef is not set", func() {
+		It("should return error when subnetRef is not set", func() {
 			instance := &osacv1alpha1.ComputeInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ci-no-subnet",
 					Namespace: namespaceName,
 				},
-				Spec: newTestComputeInstanceSpec("test_template"),
+				Spec: osacv1alpha1.ComputeInstanceSpec{
+					TemplateID: "test_template",
+				},
 			}
 
 			subnetNS, err := reconciler.resolveSubnetTargetNamespace(ctx, instance)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError(errSubnetRequired))
 			Expect(subnetNS).To(BeEmpty())
 		})
 
@@ -2310,7 +2315,7 @@ var _ = Describe("ComputeInstance Controller", func() {
 			Expect(ciAfter.Annotations).To(Equal(annotationsBefore), "Annotations should be unchanged across reconciles")
 		})
 
-		It("should not set subnet-target-namespace annotation when subnetRef is empty", func() {
+		It("should fail reconciliation when subnetRef is empty", func() {
 			const resourceName = "test-ci-no-subnet-vm-ns"
 			const tenantName = "tenant-no-subnet-vm"
 			defer deleteCI(resourceName)
@@ -2326,7 +2331,19 @@ var _ = Describe("ComputeInstance Controller", func() {
 						osacTenantAnnotation: tenantName,
 					},
 				},
-				Spec: newTestComputeInstanceSpec("test_template"),
+				Spec: osacv1alpha1.ComputeInstanceSpec{
+					TemplateID: "test_template",
+					Image: osacv1alpha1.ImageSpec{
+						SourceType: osacv1alpha1.ImageSourceTypeRegistry,
+						SourceRef:  "quay.io/fedora/fedora-coreos:stable",
+					},
+					Cores:     4,
+					MemoryGiB: 8,
+					BootDisk: osacv1alpha1.DiskSpec{
+						SizeGiB: 30,
+					},
+					RunStrategy: osacv1alpha1.RunStrategyAlways,
+				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
@@ -2336,16 +2353,8 @@ var _ = Describe("ComputeInstance Controller", func() {
 				return controllerReconciler.Client.Get(ctx, nn, &osacv1alpha1.ComputeInstance{})
 			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
 
-			// When no subnetRef, should use tenant namespace (default behavior)
 			_, err := controllerReconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{NamespacedName: nn}})
-			Expect(err).NotTo(HaveOccurred())
-
-			ci := &osacv1alpha1.ComputeInstance{}
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, nn, ci)).To(Succeed())
-				g.Expect(ci.Status.Phase).To(Equal(osacv1alpha1.ComputeInstancePhaseStarting))
-				g.Expect(ci.Annotations).NotTo(HaveKey(osacSubnetTargetNamespaceAnnotation))
-			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+			Expect(err).To(MatchError(errSubnetRequired))
 		})
 	})
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -26,6 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -152,6 +154,28 @@ func (noopProvisioningProvider) GetDeprovisionStatus(_ context.Context, _ client
 
 func (noopProvisioningProvider) Name() string { return "noop" }
 
+const testSubnetRef = "ci-test-subnet"
+
+// ensureTestSubnet creates the standard test Subnet CR in the given namespace if it does not exist.
+func ensureTestSubnet(ctx context.Context, namespace string) {
+	subnet := &osacv1alpha1.Subnet{}
+	nn := client.ObjectKey{Name: testSubnetRef, Namespace: namespace}
+	err := k8sClient.Get(ctx, nn, subnet)
+	if err != nil && errors.IsNotFound(err) {
+		subnet = &osacv1alpha1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testSubnetRef,
+				Namespace: namespace,
+			},
+			Spec: osacv1alpha1.SubnetSpec{
+				VirtualNetwork: "test-vnet",
+				IPv4CIDR:       "10.0.0.0/24",
+			},
+		}
+		Expect(k8sClient.Create(ctx, subnet)).To(Succeed())
+	}
+}
+
 // newTestComputeInstanceSpec creates a valid ComputeInstanceSpec for testing
 func newTestComputeInstanceSpec(templateID string) osacv1alpha1.ComputeInstanceSpec {
 	return osacv1alpha1.ComputeInstanceSpec{
@@ -166,5 +190,8 @@ func newTestComputeInstanceSpec(templateID string) osacv1alpha1.ComputeInstanceS
 			SizeGiB: 30,
 		},
 		RunStrategy: osacv1alpha1.RunStrategyAlways,
+		NetworkAttachments: []osacv1alpha1.NetworkAttachment{
+			{SubnetRef: testSubnetRef},
+		},
 	}
 }


### PR DESCRIPTION
## [OSAC-496](https://redhat.atlassian.net/browse/OSAC-496): Remove subnet/tenant fallback dead code (osac-operator)

**Jira:** https://redhat.atlassian.net/browse/OSAC-496
**Companion PR:** https://github.com/osac-project/fulfillment-service/pull/704

### Summary

Removes dead fallback paths in the ComputeInstance controller after subnet became mandatory. Empty primary subnet reference is a permanent reconciliation error. VM lookup always uses the subnet target namespace — no fallback to tenant namespace.

### Changes

- Added `errSubnetRequired` sentinel; `resolveSubnetTargetNamespace()` errors on empty subnet ref
- Removed tenant-namespace fallback in `handleUpdate()`
- Updated controller tests; `newTestComputeInstanceSpec` includes default subnet attachment

### Testing

- **Unit/envtest:** `make test` — pass
- **Smoke:** `make test-smoke` — pass
- **Lint:** `make lint` — pass

### Acceptance Criteria

- [x] No implicit fallback to tenant namespace in osac-operator
- [x] Empty SubnetRef treated as an error in the operator
- [x] All tests pass

### Notes

Legacy ComputeInstances without `networkAttachments[0].subnetRef` will fail reconciliation permanently (intentional per [OSAC-496](https://redhat.atlassian.net/browse/OSAC-496)).